### PR TITLE
Use *CURLIB for dataqueue entry

### DIFF
--- a/ile/src/pub_json.cpp
+++ b/ile/src/pub_json.cpp
@@ -104,7 +104,7 @@ int json_publish(const char *_session_id, std::string &_json)
   memcpy(dtaq_key, _session_id, MIN(11, strlen(_session_id)));
 
   QSNDDTAQ("MANZANDTAQ",
-           "JESSEG    ", // TODO: How to properly resolve the library here?
+           "*CURLIB   ", // TODO: How to properly resolve the library here?
            strlen(utf8),
            utf8,
            (_Decimal(3,0))10,


### PR DESCRIPTION
No longer hardcoding the library used for the dataqueue. Will be inherited from the job above.