### PR TITLE
Allow events to specify format

### DIFF
--- a/camel/src/main/java/com/github/theprez/manzan/configuration/DataConfig.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/DataConfig.java
@@ -45,6 +45,7 @@ public class DataConfig extends Config {
             }
             final String name = section;
             final String schema = ApplicationConfig.get().getLibrary();
+            final String format = getOptionalString(name, "format");
             final int interval = 5; // TODO: get from configuration
             final int numToProcess = 1000; // TODO: get from configuration
             final List<String> destinations = new LinkedList<String>();
@@ -59,10 +60,10 @@ public class DataConfig extends Config {
             }
             switch (type) {
                 case "watch":
-                    ret.put(name, new WatchMsgEvent(name, getRequiredString(name, "id"), destinations, schema, interval, numToProcess));
+                    ret.put(name, new WatchMsgEvent(name, getRequiredString(name, "id"), format, destinations, schema, interval, numToProcess));
                     break;
                 case "file":
-                    ret.put(name, new FileEvent(name, getRequiredString(name, "file"), destinations, getOptionalString(name, "filter")));
+                    ret.put(name, new FileEvent(name, getRequiredString(name, "file"), format, destinations, getOptionalString(name, "filter")));
                     break;
                 default:
                     throw new RuntimeException("Unknown destination type: " + type);

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
@@ -45,7 +45,7 @@ public class DestinationConfig extends Config {
             final String name = section;
             switch (type) {
                 case "stdout":
-                    ret.put(name, new StreamDestination(name));
+                    ret.put(name, new StreamDestination(name,getOptionalString(name, "format")));
                     break;
                 case "slack": {
                     final String webhook = getRequiredString(name, "webhook");

--- a/camel/src/main/java/com/github/theprez/manzan/routes/ManzanGenericCamelRoute.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/ManzanGenericCamelRoute.java
@@ -15,7 +15,7 @@ import com.github.theprez.manzan.ManzanMessageFormatter;
 public abstract class ManzanGenericCamelRoute extends ManzanRoute {
 
     private final String m_camelComponent;
-    private final String m_format;
+    private final ManzanMessageFormatter m_formatter;
     private final Map<String, Object> m_headerParams;
     private final String m_path;
     private final Map<String, String> m_uriParams;
@@ -27,7 +27,8 @@ public abstract class ManzanGenericCamelRoute extends ManzanRoute {
         m_headerParams = null == _headerParams ? new HashMap<String, Object>(1) : _headerParams;
         m_camelComponent = _camelComponent;
         m_path = _path;
-        m_format = _format;
+        m_formatter = StringUtils.isEmpty(_format) ? null: new ManzanMessageFormatter(_format);
+      
     }
 
     protected abstract void customPostProcess(Exchange exchange);
@@ -36,10 +37,8 @@ public abstract class ManzanGenericCamelRoute extends ManzanRoute {
     public void configure() {
         from(getInUri())
                 .process(exchange -> {
-                    if (StringUtils.isNonEmpty(m_format)) {
-                        final ManzanMessageFormatter formatter = new ManzanMessageFormatter(m_format);
-                        final String formatted = formatter.format(getDataMap(exchange));
-                        exchange.getIn().setBody(formatted);
+                    if (null != m_formatter) {
+                        exchange.getIn().setBody(m_formatter.format(getDataMap(exchange)));
                     }
                     for (final Entry<String, Object> headerEntry : m_headerParams.entrySet()) {
                         exchange.getIn().setHeader(headerEntry.getKey(), headerEntry.getValue());

--- a/camel/src/main/java/com/github/theprez/manzan/routes/dest/StreamDestination.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/dest/StreamDestination.java
@@ -1,18 +1,15 @@
 package com.github.theprez.manzan.routes.dest;
 
-import com.github.theprez.manzan.routes.ManzanRoute;
+import org.apache.camel.Exchange;
 
-public class StreamDestination extends ManzanRoute {
-    public StreamDestination(final String _name) {
-        super(_name);
+import com.github.theprez.manzan.routes.ManzanGenericCamelRoute;
+
+public class StreamDestination extends ManzanGenericCamelRoute {
+    public StreamDestination(final String _name, final String _format) {
+        super(_name, "stream", "out", _format, null, null);
     }
 
-//@formatter:off
     @Override
-    public void configure() {
-        from(getInUri())
-        .routeId(m_name).to("stream:out");
+    protected void customPostProcess(Exchange exchange) {
     }
-    //@formatter:on
-
 }

--- a/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchMsgEvent.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchMsgEvent.java
@@ -3,7 +3,9 @@ package com.github.theprez.manzan.routes.event;
 import java.io.IOException;
 import java.util.List;
 
+import com.github.theprez.jcmdutils.StringUtils;
 import com.github.theprez.manzan.ManzanEventType;
+import com.github.theprez.manzan.ManzanMessageFormatter;
 import com.github.theprez.manzan.routes.ManzanRoute;
 
 public class WatchMsgEvent extends ManzanRoute {
@@ -12,12 +14,14 @@ public class WatchMsgEvent extends ManzanRoute {
     private final int m_numToProcess;
     private final String m_schema;
     private final String m_sessionId;
+    private final ManzanMessageFormatter m_formatter;
 
-    public WatchMsgEvent(final String _name, final String _session_id, final List<String> _destinations, final String _schema, final int _interval, final int _numToProcess) throws IOException {
+    public WatchMsgEvent(final String _name, final String _session_id, final String _format, final List<String> _destinations, final String _schema, final int _interval, final int _numToProcess) throws IOException {
         super(_name);
         m_interval = _interval;
         m_numToProcess = _numToProcess;
         m_schema = _schema;
+        m_formatter = StringUtils.isEmpty(_format) ? null: new ManzanMessageFormatter(_format);
         super.setRecipientList(_destinations);
         m_sessionId = _session_id.trim().toUpperCase();
     }
@@ -35,8 +39,13 @@ public class WatchMsgEvent extends ManzanRoute {
             .setHeader("id", simple("${body[ORDINAL_POSITION]}"))
             .setHeader("session_id", simple("${body[SESSION_ID]}"))
             .setHeader("data_map", simple("${body}"))
-            .marshal().json(true)
+            .marshal().json(true) //TODO: skip this if we are applying a format
             .setBody(simple("${body}\n"))
+            .process(exchange -> {
+                if (null != m_formatter) {
+                    exchange.getIn().setBody(m_formatter.format(getDataMap(exchange)));
+                }
+            })
             .recipientList(constant(getRecipientList())).parallelProcessing().stopOnException().end()
             .setBody(simple("delete fRoM " + m_schema + ".mAnZaNmSg where ORDINAL_POSITION = ${header.id} WITH NC"))
             .to("jdbc:jt400").to("stream:err");


### PR DESCRIPTION
OK, so now format can be specified on either the event or the destination. 

For instance, `data.ini`:
```ini
[logfile1]
type=file
file=test.txt
destinations=email_bollocks, test_out
filter=error
format=Data from file "$FILE_NAME$": $FILE_DATA$
```
and `dests.ini`:
```ini
[email_bollocks]
type=smtp
format=Hey, check out this information!! \n\n$FILE_DATA$
  server = my.smtpserver.com
  subject = Testemail
  from=me@mycompany.com
  to=me@mycompany.com


[test_out]
type=stdout
```

would result in stdout getting
```
Data from file "test.txt": error happened...
```  
while the email would contain:
```
Hey, check out this information!! 

error happened...
```


The previous design allowed format to only be specified on the destination. This is nonsensical for 1-to-1 mappings because the fields will vary depending on the event type, so the user would have to be diligent to only send a certain event type to that destination (for instance, `$FILE_DATA$` would only be present for a file watch). 

It is more sensible to have the formatting aligned with the event for this reason, but there still may be a need to differentiate based on the ultimate destination. 
