### PR TITLE
Add `strwch` option to autostart system watch

### DIFF
--- a/camel/src/main/java/com/github/theprez/manzan/WatchStarter.java
+++ b/camel/src/main/java/com/github/theprez/manzan/WatchStarter.java
@@ -1,0 +1,79 @@
+package com.github.theprez.manzan;
+
+import java.io.IOException;
+
+import org.ini4j.InvalidFileFormatException;
+
+import com.github.theprez.manzan.configuration.ApplicationConfig;
+import com.ibm.as400.access.AS400;
+import com.ibm.as400.access.AS400Message;
+import com.ibm.as400.access.AS400SecurityException;
+import com.ibm.as400.access.CommandCall;
+import com.ibm.as400.access.ErrorCompletingRequestException;
+
+public class WatchStarter {
+    private final String m_command;
+    private final String m_stopCommand;
+    private final String m_session_id;
+
+    public WatchStarter(final String _session_id, final String _deets) throws InvalidFileFormatException, IOException {
+
+        String command = _deets;
+        String wchpgm = " WCHPGM(" + ApplicationConfig.get().getLibrary() + "/HANDLER) ";
+        command = command.replaceAll("(?i)(^|\\s+)wchpgm\\([A-Z0-9\\/\\*\\s]+\\)\\s*", " ");
+
+        String ssnid = " SSNID(" + _session_id + ") ";
+        command = command.replaceAll("(?i)(^|\\s+)ssnid\\([A-Z0-9\\*\\s]+\\)\\s*", " ");
+
+        command = command.replaceFirst("^(?i)([a-z0-9]+\\/)?strwch\\s+", " ");
+        command = "QSYS/STRWCH" + ssnid + wchpgm + command;
+        m_command = command;
+        m_stopCommand = "QSYS/ENDWCH SSNID(" + _session_id.trim() + ")";
+        m_session_id = _session_id;
+    }
+
+    public void endwch()
+            throws AS400SecurityException, ErrorCompletingRequestException, IOException, InterruptedException {
+        System.out.println("ending watch");
+        runCmd(m_stopCommand);
+    }
+
+    public void strwch()
+            throws IOException, AS400SecurityException, ErrorCompletingRequestException, InterruptedException {
+        runCmd(m_command);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                endwch();
+            } catch (AS400SecurityException | ErrorCompletingRequestException | IOException | InterruptedException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }));
+        System.out.println("Watch " + m_session_id + " started successfully");
+    }
+
+    public boolean isRunning()
+            throws AS400SecurityException, ErrorCompletingRequestException, IOException, InterruptedException {
+        // TODO: how to implement?
+        return false;
+    }
+
+    private static void runCmd(final String _command)
+            throws AS400SecurityException, ErrorCompletingRequestException, IOException, InterruptedException {
+        AS400 as400 = IBMiConnectionSupplier.getSystemConnection();
+        CommandCall cmd = new CommandCall(as400, _command);
+        boolean isSuccess = cmd.run();
+
+        // Show the messages (returned whether or not there was an error.)
+        AS400Message[] messagelist = cmd.getMessageList();
+        String messages = "";
+        for (AS400Message msg : messagelist) {
+            System.out.println(msg.getText());
+            messages += msg;
+            messages += "\n";
+        }
+        if (!isSuccess) {
+            throw new IOException("Failed to start watch: " + messages);
+        }
+    }
+}

--- a/camel/src/main/java/com/github/theprez/manzan/WatchStarter.java
+++ b/camel/src/main/java/com/github/theprez/manzan/WatchStarter.java
@@ -1,15 +1,23 @@
 package com.github.theprez.manzan;
 
+import java.beans.PropertyVetoException;
 import java.io.IOException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.ini4j.InvalidFileFormatException;
 
 import com.github.theprez.manzan.configuration.ApplicationConfig;
 import com.ibm.as400.access.AS400;
+import com.ibm.as400.access.AS400Bin4;
 import com.ibm.as400.access.AS400Message;
 import com.ibm.as400.access.AS400SecurityException;
+import com.ibm.as400.access.AS400Text;
 import com.ibm.as400.access.CommandCall;
+import com.ibm.as400.access.ErrorCodeParameter;
 import com.ibm.as400.access.ErrorCompletingRequestException;
+import com.ibm.as400.access.ObjectDoesNotExistException;
+import com.ibm.as400.access.ProgramCall;
+import com.ibm.as400.access.ProgramParameter;
 
 public class WatchStarter {
     private final String m_command;
@@ -39,7 +47,12 @@ public class WatchStarter {
     }
 
     public void strwch()
-            throws IOException, AS400SecurityException, ErrorCompletingRequestException, InterruptedException {
+            throws IOException, AS400SecurityException, ErrorCompletingRequestException, InterruptedException,
+            PropertyVetoException, ObjectDoesNotExistException {
+        if (isRunning()) {
+            System.err.println("Watch '" + m_session_id + "' already running");
+            return;
+        }
         runCmd(m_command);
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
@@ -53,9 +66,40 @@ public class WatchStarter {
     }
 
     public boolean isRunning()
-            throws AS400SecurityException, ErrorCompletingRequestException, IOException, InterruptedException {
-        // TODO: how to implement?
-        return false;
+            throws AS400SecurityException, ErrorCompletingRequestException, IOException, InterruptedException,
+            PropertyVetoException, ObjectDoesNotExistException {
+        AS400 as400 = IBMiConnectionSupplier.getSystemConnection();
+        ProgramCall pc = new ProgramCall(as400);
+
+        final ProgramCall program = new ProgramCall(as400);
+        // Initialize the name of the program to run.
+        final String programName = "/qsys.lib/QSCRWCHI.pgm";
+        final String sessionParmString = (m_session_id + "           ").substring(0, 10).toUpperCase();
+
+        // Set up the parms
+        final ProgramParameter[] parameterList = new ProgramParameter[5];
+        // 1 Receiver variable Output Char(*)
+        byte[] output = new byte[8];
+        parameterList[0] = new ProgramParameter(output);
+        // 2 Length of receiver variable Input Binary(4)
+        parameterList[1] = new ProgramParameter(new AS400Bin4().toBytes(output.length));
+        // 3 Receiver format name Input Char(8)
+        parameterList[2] = new ProgramParameter(new AS400Text(8).toBytes("WCHI0100"));
+        // 4 Session ID Input Char(10)
+        parameterList[3] = new ProgramParameter(new AS400Text(10).toBytes(sessionParmString));
+        // 5 Error Code I/O Char(*)
+        final ErrorCodeParameter ec = new ErrorCodeParameter(true, true);
+        parameterList[4] = ec;
+        program.setProgram(programName, parameterList);
+        boolean isSuccess = program.run();
+        for (AS400Message msg : program.getMessageList()) {
+            System.err.println(msg.getText());
+        }
+        if (!isSuccess) {
+            return false;
+        }
+        String errmsg = ec.getMessageID();
+        return StringUtils.isEmpty(errmsg);
     }
 
     private static void runCmd(final String _command)

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/DataConfig.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/DataConfig.java
@@ -1,5 +1,6 @@
 package com.github.theprez.manzan.configuration;
 
+import java.beans.PropertyVetoException;
 import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -17,6 +18,7 @@ import com.github.theprez.manzan.routes.event.FileEvent;
 import com.github.theprez.manzan.routes.event.WatchMsgEvent;
 import com.ibm.as400.access.AS400SecurityException;
 import com.ibm.as400.access.ErrorCompletingRequestException;
+import com.ibm.as400.access.ObjectDoesNotExistException;
 
 public class DataConfig extends Config {
 
@@ -33,7 +35,7 @@ public class DataConfig extends Config {
         m_destinations = _destinations;
     }
 
-    public synchronized Map<String, ManzanRoute> getRoutes() throws IOException, AS400SecurityException, ErrorCompletingRequestException, InterruptedException {
+    public synchronized Map<String, ManzanRoute> getRoutes() throws IOException, AS400SecurityException, ErrorCompletingRequestException, InterruptedException, PropertyVetoException, ObjectDoesNotExistException {
         if (null != m_routes) {
             return m_routes;
         }

--- a/camel/src/main/java/com/github/theprez/manzan/routes/event/FileEvent.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/event/FileEvent.java
@@ -39,7 +39,7 @@ public class FileEvent extends ManzanRoute {
     @Override
     public void configure() {
         from("timer://foo?period=5000&synchronous=true")
-        .routeId("file://"+m_file.getAbsolutePath())
+        .routeId(m_name)
         .setHeader(EVENT_TYPE, constant(ManzanEventType.FILE))
         .setBody(constant(m_file.getAbsolutePath()))
         .process((exchange) -> {


### PR DESCRIPTION
Introduces a `strwch` option to `data.ini`'s watch event which allows for auto starting/stopping of the watch

Example configuration in `data.ini`:

```ini
[watchout]
type=watch
id=jesse
destinations=test_out, slackme
format=$MESSAGE_ID$ (severity $SEVERITY$): $MESSAGE$ 
strwch=STRWCH SSNID(ZZZ) WCHPGM(MANZAN/HANDLER) CALLWCHPGM(*STRWCH) WCHMSG((*ALL)) WCHMSGQ((*HSTLOG))
```

Of note: the `STRWCH` command name, as well as the `SSNID` and `WCHPGM` arguments are optional. All will be replaced with appropriate values as needed. For instance, the above configuration could more concisely be written as:

```ini
[watchout]
type=watch
id=jesse
destinations=test_out, slackme
format=$MESSAGE_ID$ (severity $SEVERITY$): $MESSAGE$ 
strwch=WCHMSG((*ALL)) WCHMSGQ((*HSTLOG))
```