### PR TITLE
Add HTTP destination

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -40,7 +40,7 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-twilio</artifactId>
       <version>3.14.0</version>
-  </dependency>
+    </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-main</artifactId>
@@ -80,6 +80,11 @@
       <artifactId>camel-kafka</artifactId>
       <version>3.14.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-http</artifactId>
+      <version>3.14.0</version>
+    </dependency>
 
 
     <dependency>
@@ -103,11 +108,15 @@
       <artifactId>sentry</artifactId>
       <version>6.10.0</version>
     </dependency>
-
     <dependency>
       <groupId>org.ini4j</groupId>
       <artifactId>ini4j</artifactId>
       <version>0.5.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.10</version>
     </dependency>
 
     <dependency>

--- a/camel/src/main/java/com/github/theprez/manzan/ManzanMessageFormatter.java
+++ b/camel/src/main/java/com/github/theprez/manzan/ManzanMessageFormatter.java
@@ -2,6 +2,9 @@ package com.github.theprez.manzan;
 
 import java.util.Map;
 import java.util.Map.Entry;
+
+import com.google.gson.Gson;
+
 import java.util.WeakHashMap;
 
 public class ManzanMessageFormatter {
@@ -25,13 +28,23 @@ public class ManzanMessageFormatter {
 
     public String format(final Map<String, Object> _mappings) {
         String ret = m_fmtStr;
-        for (final Entry<String, Object> repl : _mappings.entrySet()) {
-            ret = ret.replace("$" + repl.getKey() + "$", "" + repl.getValue());
-        }
         ret = ret.replace("\r\n", "\n");
         ret = ret.replace("\r", "");
         ret = ret.replace("\\n", "\n").replace("\\t", "\t");
 
+        for (final Entry<String, Object> repl : _mappings.entrySet()) {
+            ret = ret.replace("$" + repl.getKey() + "$", "" + repl.getValue());
+            String jsonIndicator ="$json:" + repl.getKey() + "$"; 
+            if(ret.contains(jsonIndicator)) {
+                ret = ret.replace(jsonIndicator, jsonEncode("" + repl.getValue()));
+            }
+        }
         return ret;
+    }
+
+    private CharSequence jsonEncode(String _s) {
+        Gson gson = new Gson();
+        String json = gson.toJson(_s);
+        return json;
     }
 }

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
@@ -16,6 +16,7 @@ import com.github.theprez.jcmdutils.StringUtils;
 import com.github.theprez.manzan.routes.ManzanRoute;
 import com.github.theprez.manzan.routes.dest.EmailDestination;
 import com.github.theprez.manzan.routes.dest.FluentDDestination;
+import com.github.theprez.manzan.routes.dest.HttpDestination;
 import com.github.theprez.manzan.routes.dest.KafkaDestination;
 import com.github.theprez.manzan.routes.dest.SentryDestination;
 import com.github.theprez.manzan.routes.dest.SlackDestination;
@@ -61,7 +62,7 @@ public class DestinationConfig extends Config {
                     break;
                 case "kafka":
                     final String topic = getRequiredString(name, "topic");
-                    ret.put(name, new KafkaDestination(name, topic, format, getUriParameters(name, sectionObj, "topic")));
+                    ret.put(name, new KafkaDestination(name, topic, format, getUriAndHeaderParameters(name, sectionObj, "topic")));
                     break;
                 case "sentry":
                     final String dsn = getRequiredString(name, "dsn");
@@ -75,14 +76,18 @@ public class DestinationConfig extends Config {
                     break;
                 case "smtp":
                     final String server = getRequiredString(name, "server");
-                    final EmailDestination d = new EmailDestination(name, server, format, getUriParameters(name, sectionObj, "server"), null);
+                    final EmailDestination d = new EmailDestination(name, server, format, getUriAndHeaderParameters(name, sectionObj, "server"), null);
                     ret.put(name, d);
                     break;
                 case "twilio":
                     final String sid = getRequiredString(name, "sid");
                     final String token = getRequiredString(name, "token");
                     ret.put(name, new TwilioDestination(context, name, format, sid, token, 
-                    getUriParameters(name, sectionObj, "sid", "token")));
+                    getUriAndHeaderParameters(name, sectionObj, "sid", "token")));
+                    break;
+                case "http":
+                    final String url = getRequiredString(name, "url");
+                    ret.put(name, HttpDestination.get(name, url, format, getUriAndHeaderParameters(name, sectionObj, "url")));
                     break;
                 default:
                     throw new RuntimeException("Unknown destination type: " + type);
@@ -91,7 +96,7 @@ public class DestinationConfig extends Config {
         return m_routes = ret;
     }
 
-    private Map<String, String> getUriParameters(final String _name, Section sectionObj, String... _exclusions) {
+    private Map<String, String> getUriAndHeaderParameters(final String _name, Section sectionObj, String... _exclusions) {
         final Map<String, String> pathParameters = new LinkedHashMap<String, String>();
         List<String> exclusions = new LinkedList<>(Arrays.asList(_exclusions));
         exclusions.addAll(Arrays.asList("type", "filter", "format"));

--- a/camel/src/main/java/com/github/theprez/manzan/routes/dest/HttpDestination.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/dest/HttpDestination.java
@@ -1,0 +1,41 @@
+package com.github.theprez.manzan.routes.dest;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.camel.Exchange;
+
+import com.github.theprez.manzan.routes.ManzanGenericCamelRoute;
+
+public class HttpDestination extends ManzanGenericCamelRoute {
+
+    public static HttpDestination get(final String _name, final String _url, final String _format, Map<String, String> _parameters) {
+        Map<String, Object> headerParameters = new LinkedHashMap<String,Object>();
+        Map<String, String> uriParameters = new LinkedHashMap<String,String>();
+        String hostVal = _url.replaceFirst("^http://", "").replaceAll("\\/.*","");
+        headerParameters.put("Host", hostVal);
+        headerParameters.put("User-Agent", "Manzan/1.0");
+        for(Entry<String, String> parmEntry : _parameters.entrySet()) {
+            if("Host".equalsIgnoreCase(parmEntry.getKey())) {
+                headerParameters.put("Host", parmEntry.getValue());
+            }else if("Content-Type".equalsIgnoreCase(parmEntry.getKey())) {
+                headerParameters.put("Content-Type", parmEntry.getValue());
+            } else if("Content-Encoding".equalsIgnoreCase(parmEntry.getKey())) {
+                headerParameters.put("Content-Encoding", parmEntry.getValue());
+            } else if (parmEntry.getKey().startsWith("Camel")) {
+                headerParameters.put(parmEntry.getKey(), parmEntry.getValue());
+            } else {
+                uriParameters.put(parmEntry.getKey(), parmEntry.getValue());
+            }
+        }
+        return new HttpDestination(_name, _url, _format, uriParameters, headerParameters);
+    }
+    private HttpDestination(final String _name, final String _url, final String _format, Map<String, String> _uriParams, Map<String, Object> _headerParams) {
+        super(_name, "http", _url.replaceFirst("^http://", ""), _format, _uriParams, _headerParams);
+    }
+
+    @Override
+    protected void customPostProcess(Exchange exchange) {
+    }
+}


### PR DESCRIPTION
Example destination config:

```ini
[restroom]
type=http
url= http://idevphp.idevcloud.com:8082/topics/manzan_rest
httpMethod=POST
Content-Type=application/vnd.kafka.json.v2+json
format={"records":[{"value":{$json:FILE_NAME$:$json:FILE_DATA$}}]}
```

https not yet supported, will add for a future enhancement