### PR TITLE
Add versioning

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -40,7 +40,7 @@ jobs:
         echo "short_sha=$(echo ${{ github.sha }} | head -c 7)" >> $GITHUB_ENV
         cat $GITHUB_ENV
     - name: Perform remote build
-      run: $ssh_command "cd $remote_build_dir && /QOpenSys/pkgs/bin/gmake/gmake manzan-${{ github.ref_name }}.zip"
+      run: $ssh_command "cd $remote_build_dir && /QOpenSys/pkgs/bin/gmake/gmake manzan-installer-${{ github.ref_name }}.jar"
     - name: Retrieve artifact
       run: $scp_dist_command
     - name: Cleanup remote build lib
@@ -72,6 +72,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./manzan-${{ github.ref_name }}.zip
-        asset_name: manzan-${{ github.ref_name }}.zip
+        asset_path: ./manzan-installer-${{ github.ref_name }}.jar
+        asset_name: manzan-installer-${{ github.ref_name }}.jar
         asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ camel/test.txt
 config/app.ini
 *.txt
 *.ini
+ile/src/mzversion.h

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config/app.ini
 *.txt
 *.ini
 ile/src/mzversion.h
+camel/src/main/java/com/github/theprez/manzan/Version.java

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ config/app.ini
 *.ini
 ile/src/mzversion.h
 camel/src/main/java/com/github/theprez/manzan/Version.java
+appinstall.jar
+manzan-installer-*.jar

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ uninstall:
 	gmake -C ile uninstall
 	gmake -C config uninstall
 
+/QOpenSys/pkgs/bin/zip:
+	/QOpenSys/pkgs/bin/yum install zip
+
 manzan-v%.zip: /QOpenSys/pkgs/bin/zip
 	echo "Building version $*"
 	system "clrlib ${MANZAN_TEMPLIB}" || system "crtlib ${MANZAN_TEMPLIB}"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,13 @@ uninstall:
 /QOpenSys/pkgs/bin/zip:
 	/QOpenSys/pkgs/bin/yum install zip
 
-manzan-v%.zip: /QOpenSys/pkgs/bin/zip
+/QOpenSys/pkgs/bin/wget:
+	/QOpenSys/pkgs/bin/yum install wget
+
+appinstall.jar: /QOpenSys/pkgs/bin/wget
+	/QOpenSys/pkgs/bin/wget -O appinstall.jar https://github.com/ThePrez/AppInstall-IBMi/releases/download/v0.0.3/appinstall-v0.0.3.jar
+
+manzan-installer-v%.jar: /QOpenSys/pkgs/bin/zip appinstall.jar
 	echo "Building version $*"
 	system "clrlib ${MANZAN_TEMPLIB}" || system "crtlib ${MANZAN_TEMPLIB}"
 	system "dltlib ${BUILDLIB}" || echo "could not delete"
@@ -37,13 +43,4 @@ manzan-v%.zip: /QOpenSys/pkgs/bin/zip
 	gmake -C config BUILDVERSION="$*" install
 	gmake -C ile BUILDVERSION="$*"
 	gmake -C camel BUILDVERSION="$*" clean install
-	system "crtsavf ${MANZAN_TEMPLIB}/distqsys"
-	system "crtsavf ${MANZAN_TEMPLIB}/diststmf"
-	rm -f /qsys.lib/${MANZAN_TEMPLIB}.lib/*.MODULE
-	system "SAV DEV('/qsys.lib/${MANZAN_TEMPLIB}.lib/distqsys.file') OBJ(('/qsys.lib/manzan.lib')) SAVACT(*YES)"
-	cp /qsys.lib/${MANZAN_TEMPLIB}.lib/distqsys.file .
-	system "SAV DEV('/qsys.lib/${MANZAN_TEMPLIB}.lib/diststmf.file') OBJ(('/opt/manzan') ('/QOpenSys/etc/manzan')) SAVACT(*YES)"
-	cp /qsys.lib/${MANZAN_TEMPLIB}.lib/diststmf.file .
-	/QOpenSys/pkgs/bin/zip -v -0 $@ diststmf.file distqsys.file
-	rm diststmf.file distqsys.file
-	system "dltlib ${MANZAN_TEMPLIB}"
+	/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java -jar appinstall.jar --qsys manzan --dir /QOpenSys/etc/manzan --file /opt/manzan -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+BUILDLIB:=MANZAN
+MANZAN_TEMPLIB:=MANZANBLD
+BUILDVERSION:="Development build \(built with Make\)"
 
 .PHONY: ile camel test
 
@@ -20,3 +23,24 @@ install:
 uninstall:
 	gmake -C ile uninstall
 	gmake -C config uninstall
+
+manzan-v%.zip: /QOpenSys/pkgs/bin/zip
+	echo "Building version $*"
+	system "clrlib ${MANZAN_TEMPLIB}" || system "crtlib ${MANZAN_TEMPLIB}"
+	system "dltlib ${BUILDLIB}" || echo "could not delete"
+	system "crtlib ${BUILDLIB}"
+	system "dltlib ${BUILDLIB}"
+	rm -fr /QOpenSys/etc/manzan
+	gmake -C config BUILDVERSION="$*" install
+	gmake -C ile BUILDVERSION="$*"
+	gmake -C camel BUILDVERSION="$*" clean install
+	system "crtsavf ${MANZAN_TEMPLIB}/distqsys"
+	system "crtsavf ${MANZAN_TEMPLIB}/diststmf"
+	rm -f /qsys.lib/${MANZAN_TEMPLIB}.lib/*.MODULE
+	system "SAV DEV('/qsys.lib/${MANZAN_TEMPLIB}.lib/distqsys.file') OBJ(('/qsys.lib/manzan.lib')) SAVACT(*YES)"
+	cp /qsys.lib/${MANZAN_TEMPLIB}.lib/distqsys.file .
+	system "SAV DEV('/qsys.lib/${MANZAN_TEMPLIB}.lib/diststmf.file') OBJ(('/opt/manzan') ('/QOpenSys/etc/manzan')) SAVACT(*YES)"
+	cp /qsys.lib/${MANZAN_TEMPLIB}.lib/diststmf.file .
+	/QOpenSys/pkgs/bin/zip -v -0 $@ diststmf.file distqsys.file
+	rm diststmf.file distqsys.file
+	system "dltlib ${MANZAN_TEMPLIB}"

--- a/camel/Makefile
+++ b/camel/Makefile
@@ -1,10 +1,12 @@
 
 
+BUILDVERSION:="Development build \(built with Make\)"
+
 .PHONY: mkdirs
 
 JAVA_SRCS := $(shell find src -type f)
 target/manzan.jar: ${JAVA_SRCS} /QOpenSys/pkgs/bin/mvn
-	JAVA_HOME=/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit /QOpenSys/pkgs/bin/mvn -Djava.net.preferIPv4Stack=true package
+	JAVA_HOME=/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit /QOpenSys/pkgs/bin/mvn -Djava.net.preferIPv4Stack=true "-Dmanzan.version=${BUILDVERSION}" package
 	cp target/manzan-*-with-dependencies.jar target/manzan.jar
 
 mkdirs:

--- a/camel/Version.java.tpl
+++ b/camel/Version.java.tpl
@@ -1,0 +1,5 @@
+package com.github.theprez.manzan;
+class Version {
+      static String compileDateTime = "@timestamp@";
+      static String version = "@version@";
+}

--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -14,6 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.build.timestamp.format>E MMM dd HH:mm:ss yyyy</maven.build.timestamp.format>
+    <manzan.version>Development build (built with Maven)</manzan.version>
   </properties>
 
   <dependencyManagement>
@@ -183,7 +185,34 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>maven-replacer-plugin</artifactId>
+        <version>1.4.0</version>
+        <executions>
+            <execution>
+                <phase>process-sources</phase>
+                <goals>
+                    <goal>replace</goal>
+                </goals>
+            </execution>
+        </executions>
+        <configuration>
+            <file>Version.java.tpl</file>
+            <outputFile>src/main/java/com/github/theprez/manzan/Version.java</outputFile>
+            <replacements>
+                <replacement>
+                    <token>@version@</token>
+                    <value>${manzan.version}</value>
+                </replacement>
 
+                <replacement>
+                    <token>@timestamp@</token>
+                    <value>${maven.build.timestamp}</value>
+                </replacement>
+            </replacements>
+        </configuration>
+    </plugin>
       <!-- Allows the example to be run via 'mvn compile exec:java' -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/ile/Makefile
+++ b/ile/Makefile
@@ -1,8 +1,20 @@
 BUILDLIB:=MANZAN
+BUILDVERSION:="Development build \(built with Make\)"
 
 all: init /qsys.lib/${BUILDLIB}.lib/handler.pgm
 
 init: /qsys.lib/${BUILDLIB}.lib /qsys.lib/${BUILDLIB}.lib/manzanmsg.file /qsys.lib/${BUILDLIB}.lib/manzanoth.file /qsys.lib/${BUILDLIB}.lib/manzanpal.file /qsys.lib/${BUILDLIB}.lib/manzanvlog.file /qsys.lib/${BUILDLIB}.lib/manzandtaq.dtaq 
+
+.PHONY: src/mzversion.h
+
+src/mzversion.h:
+	rm -f $@
+	echo "#ifndef __MZVERSION_H" > $@
+	echo "#define __MZVERSION_H" >> $@
+	echo "#define MANZAN_VERSION \"${BUILDVERSION}\"" >> $@
+	echo "#define MANZAN_BUILDDATE \"$(shell date --universal)\"" >> $@
+	echo "#endif" >> $@
+	grep MANZAN_ $@
 
 /qsys.lib/${BUILDLIB}.lib:
 	system "RUNSQL SQL('create schema ${BUILDLIB}')  COMMIT(*NONE) NAMING(*SQL) "
@@ -12,8 +24,8 @@ init: /qsys.lib/${BUILDLIB}.lib /qsys.lib/${BUILDLIB}.lib/manzanmsg.file /qsys.l
 /qsys.lib/${BUILDLIB}.lib/%.pgm:
 	system "CRTPGM PGM(${BUILDLIB}/$*) MODULE($(patsubst %.module,$(BUILDLIB)/%,$(notdir $^))) ACTGRP(*CALLER)"
 
-/qsys.lib/${BUILDLIB}.lib/%.module: src/%.cpp
-	system "CRTCPPMOD MODULE(${BUILDLIB}/$*) SRCSTMF('$^') OPTION(*EVENTF) SYSIFCOPT(*IFS64IO) DBGVIEW(*SOURCE) TERASPACE(*YES *TSIFC) STGMDL(*SNGLVL) DTAMDL(*p128) DEFINE(DEBUG_ENABLED)"
+/qsys.lib/${BUILDLIB}.lib/%.module: src/%.cpp src/mzversion.h
+	system "CRTCPPMOD MODULE(${BUILDLIB}/$*) SRCSTMF('$<') OPTION(*EVENTF) SYSIFCOPT(*IFS64IO) DBGVIEW(*SOURCE) TERASPACE(*YES *TSIFC) STGMDL(*SNGLVL) DTAMDL(*p128) DEFINE(DEBUG_ENABLED)"
 
 /qsys.lib/${BUILDLIB}.lib/%.module: src/%.sqlc
 	system "CRTSQLCI OBJ(${BUILDLIB}/$*) SRCSTMF('$^') COMMIT(*NONE) DATFMT(*ISO) TIMFMT(*ISO) CVTCCSID(*JOB) COMPILEOPT('INCDIR(''src'')') SQLPATH(${BUILDLIB}) DFTRDBCOL(${BUILDLIB}) OPTION(*SQL)"

--- a/ile/src/handler.cpp
+++ b/ile/src/handler.cpp
@@ -5,11 +5,13 @@
 #include <fcntl.h>
 #include <qp0ztrc.h>
 #include <qmhrtvm.h>
+#include <qp0ztrc.h>
 #include <except.h>
 #include <QWCCVTDT.h>
 #include "manzan.h"
 #include "event_data.h"
 #include "userconf.h"
+#include "mzversion.h"
 
 static FILE *fd = NULL;
 
@@ -80,6 +82,13 @@ int main(int _argc, char **argv)
     return 0;
   }
   STRDBG();
+  if ((2 <= _argc) && (0 == strcmp("*VERSION", argv[1]) || 0 == strcmp("*VERSION  ", argv[1]) || 0 == strcmp("--version", argv[1]) || 0 == strcmp("-v", argv[1])))
+  {
+    Qp0zLprintf("Version: %s\n", MANZAN_VERSION);
+    Qp0zLprintf("Build date (UTC): %s\n", MANZAN_BUILDDATE);
+    printf("Version: %s\nBuild date (UTC): %s\n", MANZAN_VERSION, MANZAN_BUILDDATE);
+    return 0;
+  }
 
   BUFSTRN(watch_option, argv[1], 10);
   BUFSTRN(session_id, argv[2], 10);
@@ -259,7 +268,8 @@ int main(int _argc, char **argv)
   return 0;
 oh_crap:
   printf("Well, shit\n");
-  strncpy(argv[3], "*ERROR    ", 10);
+  if (4 <= _argc)
+    strncpy(argv[3], "*ERROR    ", 10);
   DEBUG("MCH exception happened!\n");
   ENDDBG();
   return 1;


### PR DESCRIPTION
With these changes, there is a new make rule that allows for versioning. For instance, one can invoke make like:
```bash
gmake manzan-v0.0.1.zip
```

There is also versioning built into the Java and ILE components. For instance,
```bash
/opt/manzan/bin/manzan --version
```

shows
```pascal
Distributor version information:
-------------------------------------------
    Version: 0.0.1
    Build date (UTC): Fri Dec 23 00:21:17 2022

ILE Handler version information:
-------------------------------------------
    Version: 0.0.1
    Build date (UTC): Fri Dec 23 00:21:07  2022
```

Adding a github action to create a release, build a distribution, and attach it shouldn't be hard from this point. 