### PR TITLE
Allow configuration dir to be overridden by system property

### DIFF
--- a/camel/src/main/java/com/github/theprez/manzan/ManzanMainApp.java
+++ b/camel/src/main/java/com/github/theprez/manzan/ManzanMainApp.java
@@ -10,6 +10,7 @@ import org.apache.camel.impl.DefaultCamelContext;
 
 import com.github.theprez.jcmdutils.StringUtils;
 import com.github.theprez.manzan.configuration.ApplicationConfig;
+import com.github.theprez.manzan.configuration.Config;
 import com.github.theprez.manzan.configuration.DataConfig;
 import com.github.theprez.manzan.configuration.DestinationConfig;
 import com.github.theprez.manzan.routes.ManzanRoute;
@@ -33,6 +34,13 @@ public class ManzanMainApp {
             printVersionInfo();
             return;
         }
+
+        for(final String arg:_args) {
+            if(arg.startsWith("--configdir=")) {
+                System.setProperty(Config.DIRECTORY_OVERRIDE_PROPERTY, arg.replaceFirst("^[^=]+=", ""));
+            }
+        }
+
         // Standard for a Camel deployment. Start by getting a CamelContext object.
         final CamelContext context = new DefaultCamelContext();
         System.out.println("Apache Camel version " + context.getVersion());

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/Config.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/Config.java
@@ -10,13 +10,22 @@ import com.github.theprez.jcmdutils.StringUtils;
 
 public abstract class Config {
 
+    public static final String DIRECTORY_OVERRIDE_PROPERTY = "manzan.configdir";
+
     protected static boolean isIBMi() {
         final String osName = System.getProperty("os.name", "Misty");
         return "os400".equalsIgnoreCase(osName) || "os/400".equalsIgnoreCase(osName);
     }
     protected static File getConfigFile(final String _name) throws IOException {
 
-        final File configDir = isIBMi() ? new File("/QOpenSys/etc/manzan") : new File(".").getAbsoluteFile();
+        final File configDir;
+        final String configDirOverride = System.getProperty(DIRECTORY_OVERRIDE_PROPERTY);
+        if(StringUtils.isNonEmpty(configDirOverride)) {
+            configDir = new File(configDirOverride).getAbsoluteFile();
+        } else {
+            configDir = isIBMi() ? new File("/QOpenSys/etc/manzan") : new File(".").getAbsoluteFile();
+        }
+
         if (!configDir.isDirectory()) {
             if (!configDir.mkdirs()) {
                 throw new IOException("Cound not create configuration directory " + configDir.getAbsolutePath());


### PR DESCRIPTION
This will enable individual tests to provide test-private configuration files. 

Example invocation would be
```bash
/opt/manzan/bin/manzan --configdir=test42/
```