### PR TITLE
Add `file` destination

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -79,6 +79,11 @@
 
     <dependency>
       <groupId>org.apache.camel</groupId>
+      <artifactId>camel-file</artifactId>
+      <version>3.14.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
       <artifactId>camel-kafka</artifactId>
       <version>3.14.7</version>
     </dependency>

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
@@ -15,6 +15,7 @@ import org.ini4j.Profile.Section;
 import com.github.theprez.jcmdutils.StringUtils;
 import com.github.theprez.manzan.routes.ManzanRoute;
 import com.github.theprez.manzan.routes.dest.EmailDestination;
+import com.github.theprez.manzan.routes.dest.FileDestination;
 import com.github.theprez.manzan.routes.dest.FluentDDestination;
 import com.github.theprez.manzan.routes.dest.HttpDestination;
 import com.github.theprez.manzan.routes.dest.KafkaDestination;
@@ -63,6 +64,10 @@ public class DestinationConfig extends Config {
                 case "kafka":
                     final String topic = getRequiredString(name, "topic");
                     ret.put(name, new KafkaDestination(name, topic, format, getUriAndHeaderParameters(name, sectionObj, "topic")));
+                    break;
+                case "file":
+                    final String file = getRequiredString(name, "file");
+                    ret.put(name, new FileDestination(name, file, format, getUriAndHeaderParameters(name, sectionObj, "file")));
                     break;
                 case "sentry":
                     final String dsn = getRequiredString(name, "dsn");

--- a/camel/src/main/java/com/github/theprez/manzan/routes/dest/FileDestination.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/dest/FileDestination.java
@@ -1,0 +1,17 @@
+package com.github.theprez.manzan.routes.dest;
+
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+
+import com.github.theprez.manzan.routes.ManzanGenericCamelRoute;
+
+public class FileDestination extends ManzanGenericCamelRoute {
+    public FileDestination(final String _name, final String _file, final String _format, final Map<String, String> _uriParams) {
+        super(_name, "file", _file, _format, _uriParams, null);
+    }
+
+    @Override
+    protected void customPostProcess(Exchange exchange) {
+    }
+}


### PR DESCRIPTION
This allows events to be redirected to a file. This was primarily added to enable test cases to process Manzan's output easier, but I can foresee other use cases as well. 

Example dests.ini content:

```ini
[filedest]
file=test42/output.txt
```