### PR TITLE
Update ibmi, build_release, and maven workflows

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -48,14 +48,14 @@ jobs:
       - name: Deploy to IBM i
         run: | 
           ici \
-            --rcwd "$remote_build_dir" \
+            --rcwd "${{ env.remote_build_dir }}" \
             --push "." \
-            --cmd "/QOpenSys/pkgs/bin/gmake --jobs=1 $jar_file" \
+            --cmd "/QOpenSys/pkgs/bin/gmake --jobs=1 ${{ env.jar_file }}" \
             --pull "." \ 
-            --ignore --cl "dltlib $build_lib" \
-            --ignore --cl "dltlib $dist_lib" \
+            --ignore --cl "dltlib ${{ env.build_lib }}" \
+            --ignore --cl "dltlib ${{ env.dist_lib }}" \
             --rcwd ".." \
-            --ignore --cmd "rm -fr $remote_build_dir /QOpenSys/etc/manzan /opt/manzan"
+            --ignore --cmd "rm -fr ${{ env.remote_build_dir }} /QOpenSys/etc/manzan /opt/manzan"
         env:
           IBMI_HOST: ${{ secrets.IBMI_HOST }}
           IBMI_USER: ${{ secrets.IBMI_USER }}
@@ -75,6 +75,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./manzan-installer-${{ github.ref_name }}.jar
-          asset_name: manzan-installer-${{ github.ref_name }}.jar
+          asset_path: ./${{ env.jar_file }}
+          asset_name: ${{ env.jar_file }}
           asset_content_type: application/zip

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,77 +1,80 @@
+# This workflow will build the jar file and upload it as a release asset.
+# It can be triggered by creating a tagged release on GitHub.
+
 name: IBM i build new release
+
 on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  release:
+    types: [created]
 
 env:
-  ssh_command: ssh ${{ secrets.IBMI_BUILD_USRPRF }}@${{ secrets.IBMI_BUILD_SYS }}
-  scp_dist_command: scp ${{ secrets.IBMI_BUILD_USRPRF }}@${{ secrets.IBMI_BUILD_SYS }}:/home/${{ secrets.IBMI_BUILD_USRPRF }}/build/${{ github.sha }}/manzan-installer-${{ github.ref_name }}.jar .
-  remote_build_dir: /home/${{ secrets.IBMI_BUILD_USRPRF }}/build/${{ github.sha }}
-  rsync_command: rsync -a --exclude='./.*' --exclude='./runners' --exclude='./.git' --exclude='./docs' --rsync-path=/QOpenSys/pkgs/bin/rsync ./ ${{ secrets.IBMI_BUILD_USRPRF }}@${{ secrets.IBMI_BUILD_SYS }}:/home/${{ secrets.IBMI_BUILD_USRPRF }}/build/${{ github.sha }}/
+  remote_build_dir: /home/${{ secrets.IBMI_USER }}/build/${{ github.sha }}/
+  jar_file: manzan-installer-${{ github.ref_name }}.jar
+  build_lib: MANZANBLD
+  dist_lib: MANZAN
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
+    environment: OSSBUILD
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Install private key
-      run: |
-        mkdir -p ~/.ssh
-        chmod 0755 ~
-        chmod 0700 ~/.ssh
-        echo  "${{ secrets.IBMI_BUILD_PVTKEY }}" > ~/.ssh/id_rsa
-        chmod 0600 ~/.ssh/id_rsa
-    - name: Disable strict host key checking
-      run: |
-        echo "Host *" > ~/.ssh/config
-        echo "  StrictHostKeyChecking no" >> ~/.ssh/config
-    - name: Create build sandbox
-      run: $ssh_command "mkdir -p $remote_build_dir"
-    - name: Clean up unnecessary files
-      run: rm -fr ./.git ./docs
-    - name: Populate build sandbox
-      run: $rsync_command
-    - name: Get short SHA ID
-      run: |
-        echo "short_sha=$(echo ${{ github.sha }} | head -c 7)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-    - name: Perform remote build
-      run: $ssh_command "cd $remote_build_dir && /QOpenSys/pkgs/bin/gmake --jobs=1 manzan-installer-${{ github.ref_name }}.jar"
-    - name: Retrieve artifact
-      run: $scp_dist_command
-    - name: Cleanup remote build lib
-      if: always()
-      run: $ssh_command "system 'dltlib MANZANBLD' || echo 'could not delete build lib'"
-    - name: Cleanup remote dist lib
-      if: always()
-      run: $ssh_command "system 'dltlib manzan'"
-    - name: Cleanup remote build dir
-      if: always()
-      run: $ssh_command "rm -fr $remote_build_dir"
-    - name: Cleanup remote stream file artifacts
-      if: always()
-      run: $ssh_command "rm -fr /QOpenSys/etc/manzan /opt/manzan"
-    - name: Create the release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-    - name: Upload *SAVF to release
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./manzan-installer-${{ github.ref_name }}.jar
-        asset_name: manzan-installer-${{ github.ref_name }}.jar
-        asset_content_type: application/zip
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
+
+      - name: Install NPM Dependencies
+        run: npm i -g @ibm/ibmi-ci
+
+      - name: Get short SHA ID
+        run: |
+          echo "short_sha=$(echo ${{ github.sha }} | head -c 7)" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+
+      - name: Clean up Unnecessary Files
+        run: rm -fr ./.git ./docs
+
+      - name: Deploy to IBM i
+        run: | 
+          ici \
+            --rcwd "$remote_build_dir" \
+            --push "." \
+            --cmd "/QOpenSys/pkgs/bin/gmake --jobs=1 $jar_file" \
+            --pull "." \ 
+            --ignore --cl "dltlib $build_lib" \
+            --ignore --cl "dltlib $dist_lib" \
+            --rcwd ".." \
+            --ignore --cmd "rm -fr $remote_build_dir /QOpenSys/etc/manzan /opt/manzan"
+        env:
+          IBMI_HOST: ${{ secrets.IBMI_HOST }}
+          IBMI_USER: ${{ secrets.IBMI_USER }}
+          IBMI_PASSWORD: ${{ secrets.IBMI_PASSWORD }}
+          IBMI_SSH_PORT: ${{ secrets.IBMI_SSH_PORT }}
+
+      - name: Get Release
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload JAR to Release
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./manzan-installer-${{ github.ref_name }}.jar
+          asset_name: manzan-installer-${{ github.ref_name }}.jar
+          asset_content_type: application/zip

--- a/.github/workflows/ibmi.yml
+++ b/.github/workflows/ibmi.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Deploy to IBM i
         run: | 
           ici \
-            --rcwd "$remote_build_dir" \
+            --rcwd "${{ env.remote_build_dir }}" \
             --push "." \
-            --cmd "/QOpenSys/pkgs/bin/gmake -C ile BUILDLIB=$ci_build_lib$short_sha uninstall all" \
-            --ignore --cl "dltlib $ci_build_lib$short_sha" \
+            --cmd "/QOpenSys/pkgs/bin/gmake -C ile BUILDLIB=${{ env.ci_build_lib }}$short_sha uninstall all" \
+            --ignore --cl "dltlib ${{ env.ci_build_lib }}$short_sha" \
             --rcwd ".." \
-            --ignore --cmd "rm -fr $remote_build_dir"
+            --ignore --cmd "rm -fr ${{ env.remote_build_dir }}"
         env:
           IBMI_HOST: ${{ secrets.IBMI_HOST }}
           IBMI_USER: ${{ secrets.IBMI_USER }}

--- a/.github/workflows/ibmi.yml
+++ b/.github/workflows/ibmi.yml
@@ -1,3 +1,5 @@
+# This workflow will build the ILE component.
+# It can be triggered by making changes in the ile directory and either pushing or creating a pull request into main.
 
 name: IBM i build CI
 
@@ -13,38 +15,48 @@ on:
 
 env:
   remote_build_dir: /home/${{ secrets.IBMI_USER }}/build/${{ github.sha }}
+  ci_build_lib: MZNCI
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
     environment: OSSBUILD
 
+    strategy:
+      matrix:
+        node-version: [18.x]
+
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v4
-      with:
-        always-auth: true
-        node-version: 18
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
 
-    - run: npm i -g @ibm/ibmi-ci
+      - name: Install NPM Dependencies
+        run: npm i -g @ibm/ibmi-ci
 
-    - name: Get short SHA ID
-      run: |
-        echo "short_sha=$(echo ${{ github.sha }} | head -c 5)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
+      - name: Get short SHA ID
+        run: |
+          echo "short_sha=$(echo ${{ github.sha }} | head -c 5)" >> $GITHUB_ENV
+          cat $GITHUB_ENV
 
-    - name: Deploy to IBM i
-      run: | 
-        ici \
-          --rcwd "$remote_build_dir" \
-          --push "." \
-          --cmd "/QOpenSys/pkgs/bin/gmake -C ile BUILDLIB=MZNCI$short_sha uninstall all" \
-          --ignore --cl "dltlib MZNCI$short_sha" \
-          --rcwd ".." \
-          --ignore --cmd "rm -fr $remote_build_dir"
-      env:
-        IBMI_HOST: ${{ secrets.IBMI_HOST }}
-        IBMI_USER: ${{ secrets.IBMI_USER }}
-        IBMI_PASSWORD: ${{ secrets.IBMI_PASSWORD }}
-        IBMI_SSH_PORT: ${{ secrets.IBMI_SSH_PORT }}
+      - name: Deploy to IBM i
+        run: | 
+          ici \
+            --rcwd "$remote_build_dir" \
+            --push "." \
+            --cmd "/QOpenSys/pkgs/bin/gmake -C ile BUILDLIB=$ci_build_lib$short_sha uninstall all" \
+            --ignore --cl "dltlib $ci_build_lib$short_sha" \
+            --rcwd ".." \
+            --ignore --cmd "rm -fr $remote_build_dir"
+        env:
+          IBMI_HOST: ${{ secrets.IBMI_HOST }}
+          IBMI_USER: ${{ secrets.IBMI_USER }}
+          IBMI_PASSWORD: ${{ secrets.IBMI_PASSWORD }}
+          IBMI_SSH_PORT: ${{ secrets.IBMI_SSH_PORT }}

--- a/.github/workflows/ibmi.yml
+++ b/.github/workflows/ibmi.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,17 +16,28 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [20.x]
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
-      with:
-        java-version: '8'
-        distribution: 'temurin'
-        cache: maven
-    - name: Build with Maven
-      working-directory: camel
-      run: mvn -B package --file pom.xml
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        working-directory: camel
+        run: mvn -B package --file pom.xml


### PR DESCRIPTION
### Changes
- Use Node 20
- Update action dependency versions
- Extract out build libraries (`MZNCI`, `MANZANBLD`, `MANZAN`) into env vars
- Simplify release workflow using`@ibm/ibmi-ci`
- Change release trigger to be on GitHub releases instead of tag
- For consistency/readability, switched to env context syntax (for example `${{ env.jar_file }}`) when referencing env vars