### PR TITLE
Enforce java provided by IBM

### DIFF
--- a/camel/src/main/java/com/github/theprez/manzan/ManzanMainApp.java
+++ b/camel/src/main/java/com/github/theprez/manzan/ManzanMainApp.java
@@ -32,6 +32,18 @@ public class ManzanMainApp {
             return;
         }
 
+        // Check to make sure we use right java version on IBM i
+        if (Config.isIBMi()){
+            // Get the Java vendor property
+            String javaVendor = System.getProperty("java.vendor");
+            // Check if the vendor is IBM
+            if (!javaVendor.toLowerCase().contains("ibm")) {
+                System.out.println("Java vendor: " + javaVendor);
+                System.err.println("Error: This application requires Java provided by IBM");
+                System.exit(1);
+            }
+        }
+
         for(final String arg:_args) {
             if(arg.startsWith("--configdir=")) {
                 System.setProperty(Config.DIRECTORY_OVERRIDE_PROPERTY, arg.replaceFirst("^[^=]+=", ""));

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/Config.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/Config.java
@@ -15,7 +15,7 @@ public abstract class Config {
     public static final String DIRECTORY_OVERRIDE_PROPERTY = "manzan.configdir";
     public static final String COMPONENT_OPTIONS_PREFIX = "componentOptions.";
 
-    protected static boolean isIBMi() {
+    public static boolean isIBMi() {
         final String osName = System.getProperty("os.name", "Misty");
         return "os400".equalsIgnoreCase(osName) || "os/400".equalsIgnoreCase(osName);
     }

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@ Building Manzan is easy for IBM i and we provide makefiles to simplify the entir
 
 ## Which Java to use
 Use a Java version provided by IBM, which is at least version 8. When running the `java -version` command, the output 
-should contain the string `IBM Semeru Runtime Certified Edition`. Otherwise, Manzan may not function properly.
+should contain the string `IBM`. Ex. `IBM Semeru Runtime Certified Edition`. Otherwise, Manzan may not function properly.
 
 ## Install from GitHub release 
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,12 +2,16 @@ This document will outline how to install Manzan on to IBM i. Manzan is install 
 
 Building Manzan is easy for IBM i and we provide makefiles to simplify the entire process.
 
+## Which Java to use
+Use a Java version provided by IBM, which is at least version 8. When running the `java -version` command, the output 
+should contain the string `IBM Semeru Runtime Certified Edition`. Otherwise, Manzan may not function properly.
+
 ## Install from GitHub release 
 
 To install from a github release, simply perform the following steps:
 1. Download the latest binary release from [the releases page](https://github.com/ThePrez/Manzan/releases)
-1. If you didn't download to IBM i directly, transfer the `.jar` file to IBM i using technique of your choice
-1. Run `java -jar <name of jar file>`
+2. If you didn't download to IBM i directly, transfer the `.jar` file to IBM i using technique of your choice
+3. Run `java -jar <name of jar file>`
 
 For instance, to install version `0.0.6`, the steps from an IBM i (using open source `wget`) would look like:
 ```bash


### PR DESCRIPTION
Update docs, to ensure user uses the correct java version.
Exit program if java version is not from IBM.
closes #178 
```
-bash-5.2$ java -jar manzan-1.0-jar-with-dependencies.jar --configdir=/Qopensys/etc/manzanjz
Java vendor: Eclipse OpenJ9
Error: This application requires Java provided by IBM
-bash-5.2$ export JAVA_HOME=/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit
-bash-5.2$ java -jar manzan-1.0-jar-with-dependencies.jar --configdir=/Qopensys/etc/manzanjz
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
Apache Camel version 3.14.8
target URI: stream://file?fileName=/tmp/mzntestoutput
STRWCH Command:
QSYS/STRWCH SSNID(jonathankk)  WCHPGM(MANZAN/HANDLER) WCHMSG((*ALL)) WCHMSGQ(JONATHAN/MANZANQ)
Watch jonathankk started successfully
```