### PR TITLE
Make socket port configurable

### DIFF
--- a/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchMsgEventSockets.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchMsgEventSockets.java
@@ -13,13 +13,22 @@ public class WatchMsgEventSockets extends ManzanRoute {
     private final Map<String, String> m_formatMap;
     private final Map<String, String> m_destMap;
     private final String m_socketIp = "0.0.0.0";
-    private final String m_socketPort = "8080";
+    private final String m_socketPort;
 
     public WatchMsgEventSockets(final String _name, final Map<String, String> _formatMap,
             final Map<String, String> _destMap) {
         super(_name);
         m_formatMap = _formatMap;
         m_destMap = _destMap;
+        m_socketPort = getSocketPort();
+    }
+
+    private String getSocketPort() {
+        String portEnv = System.getenv("MANZAN_SOCKET_PORT");
+        if (portEnv != null && portEnv.matches("\\d+")) {
+            return portEnv;
+        }
+        return "8080";
     }
 
 //@formatter:off

--- a/docs/config/messaging.md
+++ b/docs/config/messaging.md
@@ -14,6 +14,13 @@ Socket communication is recommended, because by providing a fallback option to S
 * `MANZAN_MESSAGING_PREFERENCE = SQL`: Prefer SQL based communication
 * `MANZAN_MESSAGING_PREFERENCE != SQL`: Prefer socket based communication
 
+### Messaging port
+By default, Manzan will try to use port 8080 for socket communication, but this can be changed by setting the environment variable `MANZAN_SOCKET_PORT`. Ex. 
+```cl
+ADDENVVAR ENVVAR(MANZAN_SOCKET_PORT) VALUE(8096) LEVEL(*SYS) REPLACE(*YES)
+```
+
+
 ### Setting the MANZAN_MESSAGING_PREFERENCE
 
 The `MANZAN_MESSAGING_PREFERENCE` environment variable can be set with the `ADDENVVAR` command. For example, to set the messaging preference to prefer SQL based communication run the command:

--- a/docs/config/messaging.md
+++ b/docs/config/messaging.md
@@ -20,7 +20,6 @@ By default, Manzan will try to use port 8080 for socket communication, but this 
 ADDENVVAR ENVVAR(MANZAN_SOCKET_PORT) VALUE(8096) LEVEL(*SYS) REPLACE(*YES)
 ```
 
-
 ### Setting the MANZAN_MESSAGING_PREFERENCE
 
 The `MANZAN_MESSAGING_PREFERENCE` environment variable can be set with the `ADDENVVAR` command. For example, to set the messaging preference to prefer SQL based communication run the command:

--- a/ile/src/debug.cpp
+++ b/ile/src/debug.cpp
@@ -39,7 +39,6 @@ extern "C" void DEBUG_LOG(const char *level, const char *label, const char *form
     if (env_level == NULL){
       env_level = "2"; // Show errors and warnings only
     }
-    env_level = "3";
     if (strcmp(env_level, level) >= 0 && debug_fd != NULL) {
         fprintf(debug_fd, "%s ", label); // Prepend the log level
         vfprintf(debug_fd, format, args);

--- a/ile/src/debug.cpp
+++ b/ile/src/debug.cpp
@@ -12,6 +12,10 @@ extern "C" void STRDBG()
 {
 #ifdef DEBUG_ENABLED
   debug_fd = fopen("/tmp/manzan_debug.txt", "a");
+    if (!debug_fd) {
+        perror("Failed to open debug file");
+    }
+
 #endif
 }
 
@@ -35,6 +39,7 @@ extern "C" void DEBUG_LOG(const char *level, const char *label, const char *form
     if (env_level == NULL){
       env_level = "2"; // Show errors and warnings only
     }
+    env_level = "3";
     if (strcmp(env_level, level) >= 0 && debug_fd != NULL) {
         fprintf(debug_fd, "%s ", label); // Prepend the log level
         vfprintf(debug_fd, format, args);

--- a/ile/src/pub_db2.sqlc
+++ b/ile/src/pub_db2.sqlc
@@ -53,7 +53,6 @@ struct messageParams {
 int get_socket_port() {
     const char *port_env = getenv("MANZAN_SOCKET_PORT");
     DEBUG_INFO("Socket port: %s\n", port_env);
-    printf("Socket port: %s\n", port_env);
     if (port_env != NULL) {
         char *endptr;
         errno = 0; // Reset errno before calling strtol

--- a/ile/src/pub_db2.sqlc
+++ b/ile/src/pub_db2.sqlc
@@ -16,7 +16,6 @@
   memset(dest, 0, sizeof(dest)); \
   strncpy(dest, parm ? parm : "", -1 + sizeof(dest));
 
-const int PORT = 8080;
 const std::string SERVER = "127.0.0.1";
 char* MSG_PREF_SOCKETS = "SOCKETS";
 char* MSG_PREF_SQL = "SQL";
@@ -50,14 +49,31 @@ struct messageParams {
     const char* sending_procedure_name;
 };
 
+// Function to get the MANZAN_SOCKET_PORT value or return default 8080
+int get_socket_port() {
+    const char *port_env = getenv("MANZAN_SOCKET_PORT");
+    DEBUG_INFO("Socket port: %s\n", port_env);
+    printf("Socket port: %s\n", port_env);
+    if (port_env != NULL) {
+        char *endptr;
+        errno = 0; // Reset errno before calling strtol
+        long port = strtol(port_env, &endptr, 10);
+        if (errno == 0 && *endptr == '\0' && port > 0 && port <= 65535) {
+            return (int)port;
+        }
+    }
+    return 8080; // Default port
+}
+
 bool send_message(std::string message){
     // Create a SocketClient instance
     SockClient client;
+    int port = get_socket_port();
 
     // Open a socket and connect to server
-    if (!client.openSocket(SERVER, PORT)) {
+    if (!client.openSocket(SERVER, port)) {
         // TODO: How do we want to handle this error? Drop the message, insert into table?
-        DEBUG_ERROR("Failed to connect to socket: %s:%d\n", SERVER.c_str(), PORT);
+        DEBUG_ERROR("Failed to connect to socket: %s:%d\n", SERVER.c_str(), port);
         return false;
     }
 


### PR DESCRIPTION
Closes #157 

By default manzan will use port 8080 for socket communication. This can now be overridden by setting the env var `MANZAN_SOCKET_PORT`

Tested locally.