### PR TITLE
Otlp support

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -195,6 +195,13 @@
       <artifactId>camel-test</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-otlp -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <version>1.49.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
@@ -8,29 +8,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.github.theprez.manzan.routes.dest.*;
+
 import org.apache.camel.CamelContext;
 import org.ini4j.InvalidFileFormatException;
 import org.ini4j.Profile.Section;
 
 import com.github.theprez.jcmdutils.StringUtils;
 import com.github.theprez.manzan.routes.ManzanRoute;
-import com.github.theprez.manzan.routes.dest.DirDestination;
-import com.github.theprez.manzan.routes.dest.ElasticsearchDestination;
-import com.github.theprez.manzan.routes.dest.EmailDestination;
-import com.github.theprez.manzan.routes.dest.FileDestination;
-import com.github.theprez.manzan.routes.dest.FluentDDestination;
-import com.github.theprez.manzan.routes.dest.GooglePubSubDestination;
-import com.github.theprez.manzan.routes.dest.GrafanaLokiDestination;
-import com.github.theprez.manzan.routes.dest.HttpDestination;
-import com.github.theprez.manzan.routes.dest.KafkaDestination;
-import com.github.theprez.manzan.routes.dest.MezmoDestination;
-import com.github.theprez.manzan.routes.dest.PagerDutyDestination;
-import com.github.theprez.manzan.routes.dest.ActiveMqDestination;
-import com.github.theprez.manzan.routes.dest.SentryDestination;
-import com.github.theprez.manzan.routes.dest.SlackDestination;
-import com.github.theprez.manzan.routes.dest.SplunkDestination;
-import com.github.theprez.manzan.routes.dest.StreamDestination;
-import com.github.theprez.manzan.routes.dest.TwilioDestination;
 
 public class DestinationConfig extends Config {
     public static DestinationConfig get() throws InvalidFileFormatException, IOException {
@@ -149,8 +134,12 @@ public class DestinationConfig extends Config {
                     break;
                 case "http":
                 case "https":
-                    final String url = getRequiredString(name, "url");
+                    String url = getRequiredString(name, "url");
                     ret.put(name, HttpDestination.get(context, name, type, url, format, componentOptions, getUriAndHeaderParameters(name, sectionObj, "url")));
+                    break;
+                case "otlp":
+                    url = getRequiredString(name, "url");
+                    ret.put(name, OpenTelemetryDestination.get(context, name, url, format));
                     break;
                 default:
                     throw new RuntimeException("Unknown destination type: " + type);

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/DestinationConfig.java
@@ -139,7 +139,8 @@ public class DestinationConfig extends Config {
                     break;
                 case "otlp":
                     url = getRequiredString(name, "url");
-                    ret.put(name, OpenTelemetryDestination.get(context, name, url, format));
+                    String errorRegex = getOptionalString(name, "errorRegex");
+                    ret.put(name, OpenTelemetryDestination.get(context, name, url, format, errorRegex));
                     break;
                 default:
                     throw new RuntimeException("Unknown destination type: " + type);

--- a/camel/src/main/java/com/github/theprez/manzan/routes/dest/OpenTelemetryDestination.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/dest/OpenTelemetryDestination.java
@@ -1,0 +1,186 @@
+package com.github.theprez.manzan.routes.dest;
+
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.theprez.manzan.ManzanEventType;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.opentelemetry.api.logs.Severity;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+
+
+import com.github.theprez.manzan.routes.ManzanGenericCamelRoute;
+
+public class OpenTelemetryDestination extends ManzanGenericCamelRoute {
+
+    private OpenTelemetryDestination(final CamelContext _context, final String _name, final String _url, final String _format, Map<String, Object> _headerParams) {
+        super(_context, _name, _url.startsWith("https") ? "https" : "http", _url.replaceFirst("^http(s)?://", ""), _format, null, _headerParams, null);
+    }
+
+    public static OpenTelemetryDestination get(final CamelContext _context, final String _name, final String _url, final String _format) {
+        Map<String, Object> headerParameters = new LinkedHashMap<String, Object>();
+        String hostVal = _url.replaceFirst("^http(s)?://", "").replaceAll("\\/.*", "");
+        headerParameters.put("Host", hostVal);
+        headerParameters.put("User-Agent", "Manzan/1.0");
+        return new OpenTelemetryDestination(_context, _name, _url, _format, headerParameters);
+    }
+
+    /**
+     * Transforms a map into a KvList. Kvlist is a key value list used in open telemetry protocol to specify a body with multiple keys.
+     *
+     * @param inputMap of keys and values
+     * @return A JsonObject representing the KvList
+     */
+    private JsonObject mapToKvlistValue(Map<String, Object> inputMap) {
+        JsonArray valuesArray = new JsonArray();
+
+        for (Map.Entry<String, Object> entry : inputMap.entrySet()) {
+            JsonObject kvEntry = new JsonObject();
+            kvEntry.addProperty("key", entry.getKey());
+
+            Object value = entry.getValue();
+            JsonObject jsonValue = new JsonObject();
+
+            if (value instanceof String) {
+                jsonValue.addProperty("stringValue", (String) value);
+            } else if (value instanceof Boolean) {
+                jsonValue.addProperty("boolValue", (Boolean) value);
+            } else if (value instanceof Integer) {
+                jsonValue.addProperty("intValue", (Integer) value);
+            } else if (value instanceof Long) {
+                jsonValue.addProperty("intValue", (Long) value);
+            } else if (value instanceof Double) {
+                jsonValue.addProperty("doubleValue", (Double) value);
+            } else if (value instanceof Float) {
+                jsonValue.addProperty("doubleValue", ((Float) value).doubleValue());
+            } else if (value instanceof byte[]) {
+                String base64 = Base64.getEncoder().encodeToString((byte[]) value);
+                jsonValue.addProperty("bytesValue", base64);
+            } else {
+                throw new IllegalArgumentException("Unsupported value type for key '" + entry.getKey() +
+                        "': " + value.getClass().getName());
+            }
+
+            kvEntry.add("value", jsonValue);
+            valuesArray.add(kvEntry);
+        }
+
+        JsonObject kvlistValue = new JsonObject();
+        kvlistValue.add("values", valuesArray);
+
+        JsonObject root = new JsonObject();
+        root.add("kvlistValue", kvlistValue);
+
+        return root;
+    }
+
+    private long getNanoSecondsSinceEpoch() {
+        return Instant.now().toEpochMilli() * 1_000_000;
+    }
+
+    private String constructOpenTelemetryLogMessage(long timestamp,
+                                                    int severityNumber,
+                                                    String severityText,
+                                                    String formatBody) {
+        String message = String.format(
+                        "{\n" +
+                        "  \"resourceLogs\": [{\n" +
+                        "    \"resource\": {\n" +
+                        "      \"attributes\": [\n" +
+                        "        { \"key\": \"service.name\", \"value\": { \"stringValue\": \"camel-watcher\" } }\n" +
+                        "      ]\n" +
+                        "    },\n" +
+                        "    \"scopeLogs\": [{\n" +
+                        "      \"scope\": { \"name\": \"file-watcher\" },\n" +
+                        "      \"logRecords\": [{\n" +
+                        "        \"timeUnixNano\": %d,\n" +
+                        "        \"severityNumber\": %d,\n" +
+                        "        \"severityText\": \"%s\",\n" +
+                        "        \"body\":" + "%s" +
+                        "    }]\n" +
+                        "  }]\n" +
+                        "  }]\n" +
+                        "}",
+                timestamp,
+                severityNumber,
+                severityText,
+                formatBody
+        );
+        return message;
+    }
+
+    private SeverityInfo getSeverityInfo(Exchange exchange){
+        int severityNumber;
+        String severityText;
+        long timestamp;
+        final ManzanEventType type = (ManzanEventType) exchange.getIn().getHeader(EVENT_TYPE);
+        if (type == ManzanEventType.WATCH_MSG) {
+            severityNumber = ((Integer) get(exchange, MSG_SEVERITY)) > SEVERITY_LIMIT ? Severity.ERROR.getSeverityNumber() : Severity.INFO.getSeverityNumber();
+            severityText = ((Integer) get(exchange, MSG_SEVERITY)) > SEVERITY_LIMIT ? Severity.ERROR.name() : Severity.INFO.name();
+            timestamp = Long.parseLong(getString(exchange, MSG_MESSAGE_TIMESTAMP));
+        } else if (type == ManzanEventType.WATCH_VLOG) {
+            severityNumber = Severity.FATAL.getSeverityNumber();
+            severityText = ((Integer) get(exchange, MSG_SEVERITY)) > SEVERITY_LIMIT ? Severity.ERROR.name() : Severity.INFO.name();
+            timestamp = Long.parseLong(getString(exchange, LOG_TIMESTAMP));
+        } else if (type == ManzanEventType.WATCH_PAL) {
+            severityNumber = Severity.FATAL.getSeverityNumber();
+            severityText = ((Integer) get(exchange, MSG_SEVERITY)) > SEVERITY_LIMIT ? Severity.ERROR.name() : Severity.INFO.name();
+            timestamp = Long.parseLong(getString(exchange, PAL_TIMESTAMP));
+        } else {
+            severityNumber = Severity.INFO.getSeverityNumber();
+            severityText = Severity.INFO.name();
+            timestamp = getNanoSecondsSinceEpoch();
+        }
+        return new SeverityInfo(severityNumber, severityText, timestamp);
+    }
+
+    private String constructOpenTelemetryBody(Exchange exchange){
+        String formatBody;
+        Object formatAppliedHeader = exchange.getIn().getHeader("format_applied");
+        if (formatAppliedHeader instanceof Boolean && (boolean) formatAppliedHeader) {
+            Object body = exchange.getIn().getBody();
+            formatBody = String.format("{\"stringValue\": \"%s\"}", body);
+        } else {
+            Map<String, Object> dataMap = getDataMap(exchange);
+            JsonObject formattedBody = mapToKvlistValue(dataMap);
+            formatBody = formattedBody.toString();
+        }
+        return formatBody;
+    }
+
+    @Override
+    protected void customPostProcess(Exchange exchange) throws JsonProcessingException {
+        SeverityInfo severityInfo = getSeverityInfo(exchange);
+        String formatBody = constructOpenTelemetryBody(exchange);
+        String message = constructOpenTelemetryLogMessage(severityInfo.getTimestamp(), severityInfo.getSeverityNumber(), severityInfo.getSeverityText(), formatBody);
+        exchange.getIn().setBody(message);
+    }
+}
+
+class SeverityInfo {
+    private int severityNumber;
+    private String severityText;
+    private long timestamp;
+    SeverityInfo(int severityNumber, String severityText, long timestamp) {
+        this.severityNumber = severityNumber;
+        this.severityText = severityText;
+        this.timestamp = timestamp;
+    }
+
+    public int getSeverityNumber() {
+        return severityNumber;
+    }
+
+    public String getSeverityText() {
+        return severityText;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+}

--- a/camel/src/main/java/com/github/theprez/manzan/routes/event/FileEvent.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/event/FileEvent.java
@@ -69,6 +69,7 @@ public class FileEvent extends ManzanRoute {
                 .setBody(simple("${body}\n"))
                 .process(exchange -> {
                     if (null != m_formatter) {
+                        exchange.getIn().setHeader("format_applied", true);
                         exchange.getIn().setBody(m_formatter.format(getDataMap(exchange)));
                     }
                 })

--- a/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchMsgEventSockets.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchMsgEventSockets.java
@@ -48,6 +48,7 @@ public class WatchMsgEventSockets extends ManzanRoute {
                 if (format != null) {
                     ManzanMessageFormatter m_formatter = new ManzanMessageFormatter(format);
                     exchange.getIn().setBody(m_formatter.format(getDataMap(exchange)));
+                    exchange.getIn().setHeader("format_applied", true);
                 }
                 String destinations = m_destMap.get(sessionId); // Get destinations from m_destMap
                 exchange.getIn().setHeader("destinations", destinations);

--- a/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchMsgEventSql.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchMsgEventSql.java
@@ -71,6 +71,7 @@ public class WatchMsgEventSql extends ManzanRoute {
                 .process(exchange -> {
                     if (null != m_formatter) {
                         exchange.getIn().setBody(m_formatter.format(getDataMap(exchange)));
+                        exchange.getIn().setHeader("format_applied", true);
                     }
                 })
                 .recipientList(constant(getRecipientList()))

--- a/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchTableEvent.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchTableEvent.java
@@ -58,6 +58,7 @@ public class WatchTableEvent extends ManzanRoute {
                 .process(exchange -> {
                     if (null != m_formatter) {
                         exchange.getIn().setBody(m_formatter.format(getDataMap(exchange)));
+                        exchange.getIn().setHeader("format_applied", true);
                     }
                 })
                 .recipientList(constant(getRecipientList()))

--- a/docs/config/dests.md
+++ b/docs/config/dests.md
@@ -133,5 +133,6 @@ index=manzan
 [myOtlpServer]
 type=otlp
 url=http://127.0.0.1:4318/v1/logs
+# If this regex is found, the log severity will be set to error. Otherwise, it will be info. 
 errorRegex=hit error: [0-9]?.*
 ```

--- a/docs/config/dests.md
+++ b/docs/config/dests.md
@@ -39,7 +39,7 @@ for ActiveMQ, you should write the option as `componentOptions.brokerURL=<yourAc
 | `pagerduty`      | Send data to PagerDuty          | * `routingKey`                                             | * `component` <br> * `group` <br> * `class`              |                                                                      |
 | `mezmo`          | Send data to Mezmo              | * `apiKey`                                                 | * `tags` <br> * `app`                                    |                                                                      |
 | `elasticsearch`  | Send data to Elasticsearch      | * `endpoint` <br> * `apiKey` <br> * `index`                |                                                          |                                                                      |
-| `oltp`  | Send data to OpenTelemetry server | * `url` | * `errorRegex`                                                         |                                                                      |
+| `otlp`  | Send data to OpenTelemetry server | * `url` | * `errorRegex`                                                         |                                                                      |
 
 ### Example
 
@@ -130,7 +130,7 @@ endpoint=<endpoint>
 apiKey=<api_key>
 index=manzan
 
-[myOltpServer]
+[myOtlpServer]
 type=otlp
 url=http://127.0.0.1:4318/v1/logs
 errorRegex=hit error: [0-9]?.*

--- a/docs/config/dests.md
+++ b/docs/config/dests.md
@@ -39,6 +39,7 @@ for ActiveMQ, you should write the option as `componentOptions.brokerURL=<yourAc
 | `pagerduty`      | Send data to PagerDuty          | * `routingKey`                                             | * `component` <br> * `group` <br> * `class`              |                                                                      |
 | `mezmo`          | Send data to Mezmo              | * `apiKey`                                                 | * `tags` <br> * `app`                                    |                                                                      |
 | `elasticsearch`  | Send data to Elasticsearch      | * `endpoint` <br> * `apiKey` <br> * `index`                |                                                          |                                                                      |
+| `oltp`  | Send data to OpenTelemetry server | * `url` | * `errorRegex`                                                         |                                                                      |
 
 ### Example
 
@@ -128,4 +129,9 @@ type=elasticsearch
 endpoint=<endpoint>
 apiKey=<api_key>
 index=manzan
+
+[myOltpServer]
+type=otlp
+url=http://127.0.0.1:4318/v1/logs
+errorRegex=hit error: [0-9]?.*
 ```


### PR DESCRIPTION
Closes #199 

Note. This pr only adds support for sending basic log messages to an http opentelemetry server. More advanced features can be discussed later.

To test you can run a local open telemetry server using

```
docker run \
  -p 127.0.0.1:4317:4317 \
  -p 127.0.0.1:4318:4318 \
  -p 127.0.0.1:55679:55679 \
  otel/opentelemetry-collector-contrib:latest \
  2>&1 | tee collector-output.txt
```