### PR TITLE
Allow executing arbitrary sql

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
             --rcwd "${{ env.remote_build_dir }}" \
             --push "." \
             --cmd "/QOpenSys/pkgs/bin/gmake BUILDLIB=${{ env.BUILDLIB }} install" \
+            --cmd "find . -type f -name "*.ini" -exec chmod 600 {} +" \
+            --cmd "find . -type f -name "*.ini" -exec ls -l {} +" \
         env:
           IBMI_HOST: ${{ secrets.IBMI_HOST }}
           IBMI_USER: ${{ secrets.IBMI_USER }}

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	gmake -C config install BUILDLIB=${BUILDLIB}
 	gmake -C ile BUILDLIB=${BUILDLIB}
 	gmake -C camel install
-	install -m 555 -o qsys service-commander-def.yaml ${INSTALL_ROOT}/opt/manzan/lib/manzan.yaml
+	install -m 600 -o qsys service-commander-def.yaml ${INSTALL_ROOT}/opt/manzan/lib/manzan.yaml
 
 uninstall:
 	gmake -C ile uninstall BUILDLIB=${BUILDLIB}
@@ -47,7 +47,7 @@ manzan-installer-v%.jar: /QOpenSys/pkgs/bin/zip appinstall.jar
 	gmake -C config BUILDVERSION="$*" install BUILDLIB=${BUILDLIB}
 	gmake -C ile BUILDVERSION="$*" BUILDLIB=${BUILDLIB}
 	gmake -C camel BUILDVERSION="$*" clean install
-	install -m 555 -o qsys service-commander-def.yaml ${INSTALL_ROOT}/opt/manzan/lib/manzan.yaml
+	install -m 600 -o qsys service-commander-def.yaml ${INSTALL_ROOT}/opt/manzan/lib/manzan.yaml
 	echo "#!/QOpenSys/usr/bin/sh" > .postinstall
 	echo "ln -sf ${INSTALL_ROOT}/opt/manzan/lib/manzan.yaml /QOpenSys/etc/sc/services/manzan.yaml" >> .postinstall
 	/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java -jar appinstall.jar -o $@ --qsys manzan --file /QOpenSys/etc/manzan --file /opt/manzan --post .postinstall

--- a/camel/Makefile
+++ b/camel/Makefile
@@ -16,8 +16,8 @@ mkdirs:
 	/QOpenSys/pkgs/bin/yum install maven
 
 install: mkdirs all scripts/manzan
-	install -m 444 -o qsys target/manzan.jar ${INSTALL_ROOT}/opt/manzan/lib/manzan.jar
-	install -m 555 -o qsys scripts/manzan ${INSTALL_ROOT}/opt/manzan/bin/manzan
+	install -m 700 -o qsys target/manzan.jar ${INSTALL_ROOT}/opt/manzan/lib/manzan.jar
+	install -m 700 -o qsys scripts/manzan ${INSTALL_ROOT}/opt/manzan/bin/manzan
 
 ${INSTALL_ROOT}/opt/manzan/bin/manzan:
 

--- a/camel/src/main/java/com/github/theprez/manzan/configuration/DataConfig.java
+++ b/camel/src/main/java/com/github/theprez/manzan/configuration/DataConfig.java
@@ -101,6 +101,10 @@ public class DataConfig extends Config {
                     final String userAuditType = getRequiredString(name, "auditType");
                     ret.put(name, new AuditLog(name, format, destinations, interval, numToProcess, userAuditType, fallbackStartTime));
                     break;
+                case "sql":
+                    final String query = getRequiredString(name, "query");
+                    ret.put(name, new WatchSql(name, query, format, destinations, interval));
+                    break;
                 default:
                     throw new RuntimeException("Unknown destination type: " + type);
             }

--- a/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchSql.java
+++ b/camel/src/main/java/com/github/theprez/manzan/routes/event/WatchSql.java
@@ -1,0 +1,50 @@
+
+
+
+package com.github.theprez.manzan.routes.event;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.github.theprez.jcmdutils.StringUtils;
+import com.github.theprez.manzan.ManzanMessageFormatter;
+import com.github.theprez.manzan.routes.ManzanRoute;
+
+public class WatchSql extends ManzanRoute {
+    private final int m_interval;
+    private final ManzanMessageFormatter m_formatter;
+    private final String m_sql;
+
+    public WatchSql(final String _name, final String _sql, final String _format,
+                    final List<String> _destinations,
+                    final int _interval)
+            throws IOException {
+        super(_name);
+        m_interval = _interval;
+        m_formatter = StringUtils.isEmpty(_format) ? null : new ManzanMessageFormatter(_format);
+        m_sql = _sql;
+        super.setRecipientList(_destinations);
+    }
+
+    @Override
+    public void configure() {
+        from("timer://foo?synchronous=true&period=" + m_interval)
+                .routeId("manzan_sql:" + m_name)
+                .setBody(constant(m_sql))
+                .to("jdbc:jt400?outputType=StreamList")
+                .split(body()).streaming().parallelProcessing()
+                .setHeader("data_map", simple("${body}"))
+                .marshal().json(true) // TODO: skip this if we are applying a format
+                .setBody(simple("${body}\n"))
+                .process(exchange -> {
+                    if (null != m_formatter) {
+                        exchange.getIn().setBody(m_formatter.format(getDataMap(exchange)));
+                    }
+                })
+                .recipientList(constant(getRecipientList()))
+                .parallelProcessing()
+                .stopOnException()
+                .end()
+                .end();
+    }
+}

--- a/config/Makefile
+++ b/config/Makefile
@@ -4,18 +4,16 @@ BUILDLIB?=MANZAN
 .PHONY: mkdirs app.ini
 
 mkdirs: 
-	install -m 700 -o qsys -D -d ${INSTALL_ROOT}/opt/manzan ${INSTALL_ROOT}/opt/manzan/bin ${INSTALL_ROOT}/opt/manzan/lib ${INSTALL_ROOT}/QOpenSys/etc/manzan
+	install -m 700 -o qsys -D -d ${INSTALL_ROOT}/opt/manzan ${INSTALL_ROOT}/opt/manzan/bin ${INSTALL_ROOT}/opt/manzan/lib
+	install -m 600 -o qsys -D -d ${INSTALL_ROOT}/QOpenSys/etc/manzan
 
 app.ini: app.ini.tpl
 	cat $< | /QOpenSys/usr/bin/sed  's|library=.*|library=${BUILDLIB}|g' > $@
 
-
-copyfiles: app.ini $(CURDIR)/data.ini dests.ini
-	install -m 555 -o qsys $^ ${INSTALL_ROOT}/QOpenSys/etc/manzan
+copyfiles: app.ini data.ini dests.ini
+	install -m 600 -o qsys $^ ${INSTALL_ROOT}/QOpenSys/etc/manzan
 
 install: mkdirs copyfiles
-	/QOpenSys/usr/bin/find  ${INSTALL_ROOT}/QOpenSys/etc/manzan/ -type f -print -exec chmod 600 {} \;
-	/QOpenSys/usr/bin/find  ${INSTALL_ROOT}/QOpenSys/etc/manzan/ -type l -print -exec chmod 600 {} \;
 	chown -R qsys ${INSTALL_ROOT}/QOpenSys/etc/manzan
 
 uninstall:

--- a/config/Makefile
+++ b/config/Makefile
@@ -4,7 +4,7 @@ BUILDLIB?=MANZAN
 .PHONY: mkdirs app.ini
 
 mkdirs: 
-	install -m 755 -o qsys -D -d ${INSTALL_ROOT}/opt/manzan ${INSTALL_ROOT}/opt/manzan/bin ${INSTALL_ROOT}/opt/manzan/lib ${INSTALL_ROOT}/QOpenSys/etc/manzan
+	install -m 700 -o qsys -D -d ${INSTALL_ROOT}/opt/manzan ${INSTALL_ROOT}/opt/manzan/bin ${INSTALL_ROOT}/opt/manzan/lib ${INSTALL_ROOT}/QOpenSys/etc/manzan
 
 app.ini: app.ini.tpl
 	cat $< | /QOpenSys/usr/bin/sed  's|library=.*|library=${BUILDLIB}|g' > $@
@@ -14,8 +14,8 @@ copyfiles: app.ini $(CURDIR)/data.ini dests.ini
 	install -m 555 -o qsys $^ ${INSTALL_ROOT}/QOpenSys/etc/manzan
 
 install: mkdirs copyfiles
-	/QOpenSys/usr/bin/find  ${INSTALL_ROOT}/QOpenSys/etc/manzan/ -type f -print -exec chmod 644 {} \;
-	/QOpenSys/usr/bin/find  ${INSTALL_ROOT}/QOpenSys/etc/manzan/ -type l -print -exec chmod 644 {} \;
+	/QOpenSys/usr/bin/find  ${INSTALL_ROOT}/QOpenSys/etc/manzan/ -type f -print -exec chmod 600 {} \;
+	/QOpenSys/usr/bin/find  ${INSTALL_ROOT}/QOpenSys/etc/manzan/ -type l -print -exec chmod 600 {} \;
 	chown -R qsys ${INSTALL_ROOT}/QOpenSys/etc/manzan
 
 uninstall:

--- a/docs/config/data.md
+++ b/docs/config/data.md
@@ -35,9 +35,10 @@ Some types have additional properties that they require.
 | id      | Description                                 | Required properties            | Optional properties                                                                                                        |
 |---------|---------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | `file`  | Triggered when a file changes               | `file` path of file to watch   | * `filter` only listen for lines that include this value                                                                |
-| `watch` | Triggered when the Manzan handler is called | `id` of the watch (session ID) | * `strwch` is part of the `STRWCH` CL command that can be used to describe how to start the watch when Manzan starts up <br> * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval at which to query for new messages|
-| `table` | Triggered when data is inserted into the specified table | `table` name of the table to watch  <br> `schema` the schema in which the table resides | * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval at which to query for new messages|
-| `audit` | Triggered when the specified `auditType` catches an event. | `auditType` options are `AUTHORITY_FAILURE`, `AUTHORITY_CHANGES`, `COMMAND_STRING`, `CREATE_OBJECT`, `USER_PROFILE_CHANGES`, `DELETE_OPERATION`, `ENVIRONMENT_VARIABLE`, `GENERIC_RECORD`, `JOB_CHANGE`, `OBJECT_MANAGEMENT_CHANGE`, `OWNERSHIP_CHANGE`, `PASSWORD`, `SERVICE_TOOLS_ACTION`, `ACTION_TO_SYSTEM_VALUE`, `READ_OF_OBJECT`, `CHANGE_TO_OBJECT`, `NETWORK_PASSWORD_ERROR`, `SYSTEMS_MANAGEMENT_CHANGE`, `SOCKETS_CONNECTIONS`, `PRIMARY_GROUP_CHANGE_FOR_RESTORED_OBJECT`, `OWNERSHIP_CHANGE_FOR_RESTORED_OBJECT`, `AUTHORITY_CHANGE_FOR_RESTORED_OBJECT`, `PTF_OBJECT_CHANGE`, `PROFILE_SWAP`, `PRIMARY_GROUP_CHANGE`, `PTF_OPERATIONS`, `PROGRAM_ADOPT`, `OBJECT_RESTORE`, `ATTRIBUTE_CHANGE`, `DB2_MIRROR_REPLICATION_STATE`, `DB2_MIRROR_PRODUCT_SERVICES`, `DB2_MIRROR_REPLICATION_SERVICES`, `DB2_MIRROR_COMMUNICATION_SERVICES`, `DB2_MIRROR_SETUP_TOOLS`, `LINK_UNLINK_SEARCH_DIRECTORY`, `INTRUSION_MONITOR`, `SERVICE_TOOLS_USER_ID_AND_ATTRIBUTE_CHANGES`, `ROW_AND_COLUMN_ACCESS_CONTROL`, `ATTRIBUTE_CHANGES`, `ADOPTED_AUTHORITY`, `AUDITING_CHANGE`  | * `fallbackStartTime` is the number of hours prior to the current date that we will query for audit messages, if no audit messages have been queried before <br> * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval at which to query for new messages|
+| `watch` | Triggered when the Manzan handler is called | `id` of the watch (session ID) | * `strwch` is part of the `STRWCH` CL command that can be used to describe how to start the watch when Manzan starts up <br> * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval in ms at which to query for new messages|
+| `table` | Triggered when data is inserted into the specified table | `table` name of the table to watch  <br> `schema` the schema in which the table resides | * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval in ms at which to query for new messages|
+| `audit` | Triggered when the specified `auditType` catches an event. | `auditType` options are `AUTHORITY_FAILURE`, `AUTHORITY_CHANGES`, `COMMAND_STRING`, `CREATE_OBJECT`, `USER_PROFILE_CHANGES`, `DELETE_OPERATION`, `ENVIRONMENT_VARIABLE`, `GENERIC_RECORD`, `JOB_CHANGE`, `OBJECT_MANAGEMENT_CHANGE`, `OWNERSHIP_CHANGE`, `PASSWORD`, `SERVICE_TOOLS_ACTION`, `ACTION_TO_SYSTEM_VALUE`, `READ_OF_OBJECT`, `CHANGE_TO_OBJECT`, `NETWORK_PASSWORD_ERROR`, `SYSTEMS_MANAGEMENT_CHANGE`, `SOCKETS_CONNECTIONS`, `PRIMARY_GROUP_CHANGE_FOR_RESTORED_OBJECT`, `OWNERSHIP_CHANGE_FOR_RESTORED_OBJECT`, `AUTHORITY_CHANGE_FOR_RESTORED_OBJECT`, `PTF_OBJECT_CHANGE`, `PROFILE_SWAP`, `PRIMARY_GROUP_CHANGE`, `PTF_OPERATIONS`, `PROGRAM_ADOPT`, `OBJECT_RESTORE`, `ATTRIBUTE_CHANGE`, `DB2_MIRROR_REPLICATION_STATE`, `DB2_MIRROR_PRODUCT_SERVICES`, `DB2_MIRROR_REPLICATION_SERVICES`, `DB2_MIRROR_COMMUNICATION_SERVICES`, `DB2_MIRROR_SETUP_TOOLS`, `LINK_UNLINK_SEARCH_DIRECTORY`, `INTRUSION_MONITOR`, `SERVICE_TOOLS_USER_ID_AND_ATTRIBUTE_CHANGES`, `ROW_AND_COLUMN_ACCESS_CONTROL`, `ATTRIBUTE_CHANGES`, `ADOPTED_AUTHORITY`, `AUDITING_CHANGE`  | * `fallbackStartTime` is the number of hours prior to the current date that we will query for audit messages, if no audit messages have been queried before <br> * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval in ms at which to query for new messages|
+| `sql`  | Executes arbitrary sql at a predefined interval    | `query` to be executed  | * `interval`  the interval in ms at which to run the sql statement |
 
 ### Special event types
 The `table` event type is primarily used as a mechanism to transport arbitrary data to a chosen destination. This data can be programmatically inserted into the table, or it can be inserted manually. Note that this data will be deleted from the table after it is processed. In the case that you want to persist the data in the database, consider using a different event type such as `file` or `watch`.
@@ -48,6 +49,8 @@ The `audit` event type is used to monitor events from the various IBM i [Audit j
 
 Note: You will need to enable audit journaling on your system before you can watch for audit journal events
 through Manzan. Please check out the following [documentation](https://www.ibm.com/docs/en/i/7.4.0?topic=journal-setting-up-security-auditing) for instructions on how to start the audit journal on IBM i.
+
+The `sql` event type is not watching a data source like the other event types. Instead, it is executing an sql statement provided by the user at the predefined interval (default is every second).
 
 ### Example
 
@@ -96,4 +99,11 @@ auditType=PASSWORD
 fallbackStartTime=1
 format=Violation type: $VIOLATION_TYPE_DETAIL$, username: $AUDIT_USER_NAME$
 interval=5000
+
+[sql1]
+type=sql
+query=SELECT * FROM sample.department WHERE time > CURRENT_TIMESTAMP - 5 MINUTES
+destinations=googpubsub, stdout
+format=department: $DEPTNAME$
+interval=300000
 ```

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -10,7 +10,11 @@ TESTLIB:=MZNTEST
 
 # run before every test case
 beforeAll:
-	for dir in msg/*/; do printf "[install]\nlibrary=%s\n" "${TESTLIB}" > "$$dir/app.ini"; done
+	for dir in msg/*/; do \
+		printf "[install]\nlibrary=%s\n" "${TESTLIB}" > "$$dir/app.ini"; \
+		chmod 600 "$$dir/app.ini"; \
+	done
+
 
 # Run after every test case
 afterAll:


### PR DESCRIPTION
Closes #200

- Ensure permissions on config files are set to 600 before running. This makes sure that only the owner of the config file can change it's contents
- Allow executing arbitrary sql via the sql type in data.ini

Example of permission error
```
-bash-5.2$ java -jar target/manzan-1.0-jar-with-dependencies.jar --configdir=/QOpensys/etc/manzanjz
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
Apache Camel version 3.14.8
Exception in thread "main" java.lang.SecurityException: File /QOpensys/etc/manzanjz/dests.ini does not have permission 600. Found: [GROUP_READ, OWNER_WRITE, OTHERS_READ, OWNER_READ]. Set your file permissions to 600 and retry.
        at com.github.theprez.manzan.configuration.Config.ensureOnlyOwnerCanReadAndWriteFile(Config.java:62)
        at com.github.theprez.manzan.configuration.Config.getConfigFile(Config.java:45)
        at com.github.theprez.manzan.configuration.DestinationConfig.get(DestinationConfig.java:37)
        at com.github.theprez.manzan.ManzanMainApp.main(ManzanMainApp.java:64)
```

Example of data.ini
```
[sql1]
type=sql
query=SELECT * FROM SAMPLE.DEPARTMENT
destinations=stdout
format="department: $DEPTNAME$"
```
Example output for executed sql
```
-bash-5.2$ java -jar target/manzan-1.0-jar-with-dependencies.jar --configdir=/QOpensys/etc/manzanjz
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
Apache Camel version 3.14.8
target URI: stream://file?fileName=/tmp/mzntestoutput
[                          main] AbstractCamelContext           INFO  Routes startup (total:3 started:3)
[                          main] AbstractCamelContext           INFO      Started route1 (direct://stdout)
[                          main] AbstractCamelContext           INFO      Started route2 (direct://myfile)
[                          main] AbstractCamelContext           INFO      Started manzan_sql:sql1 (timer://foo)
[                          main] AbstractCamelContext           INFO  Apache Camel 3.14.8 (camel-1) started in 413ms (build:77ms init:182ms start:154ms)
"department: OPERATIONS"
"department: PLANNING"
"department: ADMINISTRATION SYSTEMS"
"department: BRANCH OFFICE F2"
"department: DEVELOPMENT CENTER"
"department: BRANCH OFFICE G2"
"department: SPIFFY COMPUTER SERVICE DIV."
"department: SUPPORT SERVICES"
"department: INFORMATION CENTER"
```