### PR TITLE
make strwch required for type watch in docs

### DIFF
--- a/docs/config/data.md
+++ b/docs/config/data.md
@@ -35,7 +35,7 @@ Some types have additional properties that they require.
 | id      | Description                                 | Required properties            | Optional properties                                                                                                        |
 |---------|---------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | `file`  | Triggered when a file changes               | `file` path of file to watch   | * `filter` only listen for lines that include this value                                                                |
-| `watch` | Triggered when the Manzan handler is called | `id` of the watch (session ID) | * `strwch` is part of the `STRWCH` CL command that can be used to describe how to start the watch when Manzan starts up <br> * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval in ms at which to query for new messages|
+| `watch` | Triggered when the Manzan handler is called | `id` of the watch (session ID) <br> `strwch` is part of the `STRWCH` CL command that can be used to describe how to start the watch when Manzan starts up | * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval in ms at which to query for new messages|
 | `table` | Triggered when data is inserted into the specified table | `table` name of the table to watch  <br> `schema` the schema in which the table resides | * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval in ms at which to query for new messages|
 | `audit` | Triggered when the specified `auditType` catches an event. | `auditType` options are `AUTHORITY_FAILURE`, `AUTHORITY_CHANGES`, `COMMAND_STRING`, `CREATE_OBJECT`, `USER_PROFILE_CHANGES`, `DELETE_OPERATION`, `ENVIRONMENT_VARIABLE`, `GENERIC_RECORD`, `JOB_CHANGE`, `OBJECT_MANAGEMENT_CHANGE`, `OWNERSHIP_CHANGE`, `PASSWORD`, `SERVICE_TOOLS_ACTION`, `ACTION_TO_SYSTEM_VALUE`, `READ_OF_OBJECT`, `CHANGE_TO_OBJECT`, `NETWORK_PASSWORD_ERROR`, `SYSTEMS_MANAGEMENT_CHANGE`, `SOCKETS_CONNECTIONS`, `PRIMARY_GROUP_CHANGE_FOR_RESTORED_OBJECT`, `OWNERSHIP_CHANGE_FOR_RESTORED_OBJECT`, `AUTHORITY_CHANGE_FOR_RESTORED_OBJECT`, `PTF_OBJECT_CHANGE`, `PROFILE_SWAP`, `PRIMARY_GROUP_CHANGE`, `PTF_OPERATIONS`, `PROGRAM_ADOPT`, `OBJECT_RESTORE`, `ATTRIBUTE_CHANGE`, `DB2_MIRROR_REPLICATION_STATE`, `DB2_MIRROR_PRODUCT_SERVICES`, `DB2_MIRROR_REPLICATION_SERVICES`, `DB2_MIRROR_COMMUNICATION_SERVICES`, `DB2_MIRROR_SETUP_TOOLS`, `LINK_UNLINK_SEARCH_DIRECTORY`, `INTRUSION_MONITOR`, `SERVICE_TOOLS_USER_ID_AND_ATTRIBUTE_CHANGES`, `ROW_AND_COLUMN_ACCESS_CONTROL`, `ATTRIBUTE_CHANGES`, `ADOPTED_AUTHORITY`, `AUDITING_CHANGE`  | * `fallbackStartTime` is the number of hours prior to the current date that we will query for audit messages, if no audit messages have been queried before <br> * `numToProcess` can be used to configure how many messages are queried for by the distributor (default `1000`) <br> * `interval` the interval in ms at which to query for new messages|
 | `sql`  | Executes arbitrary sql at a predefined interval    | `query` to be executed  | * `interval`  the interval in ms at which to run the sql statement |
@@ -55,11 +55,12 @@ The `sql` event type is not watching a data source like the other event types. I
 ### Example
 
 ```ini
-# This will manage information from the watch session with id "jesse". It is disabled.
+# This will watch events from the QSYSOPR message queue. It is disabled.
 [watcher1]
 type=watch
-id=jesse
+id=QSYSOPR
 destinations=test_out, slackme
+strwch=WCHMSG((*ALL)) WCHMSGQ((QSYS/QSYSOPR))
 enabled=false
 ​
 # This will trigger an event whenever anything is appended to "test.txt"


### PR DESCRIPTION
This property is actually required.

```
Apache Camel version 3.14.8
Exception in thread "main" java.lang.RuntimeException: Required value for 'strwch' in [watcher1] not found
	at com.github.theprez.manzan.configuration.Config.getRequiredString(Config.java:106)
	at com.github.theprez.manzan.configuration.DataConfig.getRoutes(DataConfig.java:124)
	at com.github.theprez.manzan.ManzanMainApp.main(ManzanMainApp.java:71)
```